### PR TITLE
Enhancements to look for prod_id=XXXXX and model=YYZZ in the /proc/cmdline and /etc/product.env to select prod/model specific config-XXXXX-YYZZ default config file from our list

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -130,6 +130,45 @@ unmount_encrypted_config() {
     fi
 }
 
+
+# if necessary, provide initial config
+init_prod_model_bootfile () {
+
+    # Scan /proc/cmdline for the token 'prod_id=IOLAN|IRG|IT' and extract the model-string
+    prod_string=$(grep -oP '(?<=prod_id=)[^\s]+' /proc/cmdline)
+
+    # Scan /proc/cmdline for the token 'model=model-string' and extract the model-string
+    model_string=$(grep -oP '(?<=model=)[^\s]+' /proc/cmdline)
+
+    # Check if the model-string is found
+    if [[ -z $prod_string || -z $model_string ]]; then
+        echo "No 'prod_id' and/or 'model' token found in /proc/cmdline, checking /etc/product.env"
+        prod_string=$(grep -oP '(?<=prod_id=)[^\s]+' /etc/product.env)
+        model_string=$(grep -oP '(?<=model=)[^\s]+' /etc/product.env)
+
+        if [[ -z $prod_string || -z $model_string ]]; then
+            echo "No 'prod_id' and/or 'model' token found, use generic igos default config"
+            return
+        fi
+    fi
+
+    echo "Prod-Model string found: $prod_string-$model_string"
+
+    # Find the file with the model-string extension in /usr/libexec/vyos/init/model-info/
+    model_file="/usr/share/vyos/model-info/default-config/config-${prod_string}-${model_string}"
+
+    # Check if the file exists
+    if [ -f $model_file ]; then
+        # Copy the file to /opt/vyatta/etc/config.boot.default
+        cp $model_file $DEFAULT_BOOTFILE
+        echo "File $model_file successfully copied to /opt/vyatta/etc/config.boot.default"
+        $vyos_libexec_dir/add-system-version.py >> $DEFAULT_BOOTFILE
+        echo "System version string added to /opt/vyatta/etc/config.boot.default"
+    else
+        echo "File $model_file not found."
+    fi
+}
+
 # if necessary, provide initial config
 init_bootfile () {
     # define and version default boot config if not present
@@ -513,6 +552,8 @@ start ()
     # If for any reason FRR was not started by system_frr.py - start it anyways.
     # This is a safety net!
     systemctl start frr.service
+
+    disabled bootfile || init_prod_model_bootfile
 
     disabled bootfile || init_bootfile
 


### PR DESCRIPTION
We needed a way to use specific default config boot files based on product family and models/submodels.  The previous Perle products used 1) perle_product.h header file that included very specific product family, variants, hardware switchport re-mapping, etc 2) default json config database and 3) INITDB startup code that crafted our default json config file.   

In our VYOS-only environment, it would be easier to keep the following concepts of the bootloader passing in product id (family), and models/variants using kernel command line (/proc/cmdline) and/or and env file under /etc/product.env.  For the time being, we use the following strings:  prod_id=IOLAN | IRG | IT and model=YYZZ where YY is the model and ZZ is the sub-model or variant (with or without cellular, or wifi)   A future addition would be the starting MAC address for each unit assigned by production.  Currently, eth0 is assigned TI's OUI 1C:63:49:XX:XX:XX and subsequent ethX are auto generated.   If either prid_id or model cannot be found in /proc/cmdline or /etc/product.env, the generic config.bott.default file will be used.  For testing, a nexus-build/updates/product.env with prod_id=IOLAN  model=2A01 will be copied to build/fs/etc/product.env to be included in the rootfs.  

The list of config-XXXXX-YYZZ files specific to a prod_id=XXXXX and model=YYZZ, will be copied for nexus-build/updates/model-info/default-config/  to the rootfs user /usr/share/vyos/model-info/default-config for now, but they can be moved elsewhere if we see to need to be able to update those without rebuilding the rootfs in the future.  The usr/libexec/vyos/init/vyos-router script would need to change to stay in sync.  List of iGOS product models on Dropbox:
                          Perle Systems Dropbox\Perle\Hardware\iGOS\Models\Proposed 202501081601.xlsx