### PR TITLE
F12006:9999: add support for system login user <username> type [operator|administrator] for 2 user types

### DIFF
--- a/interface-definitions/system_login.xml.in
+++ b/interface-definitions/system_login.xml.in
@@ -194,6 +194,22 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="type">
+                <properties>
+                <help>User type: operator or administrator</help>
+                <completionHelp>
+                  <list>operator administrator</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>operator</format>
+                    <description>Operator level user tupe.</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>administrator</format>
+                    <description>Administrator level user type</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>              
             </children>
           </tagNode>
           #include <include/radius-server-ipv4-ipv6.xml.i>

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -316,7 +316,10 @@ def apply(login):
             if tmp: command += f" --home '{tmp}'"
             else: command += f" --home '/home/{user}'"
 
-            command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea {user}'
+            tmp = dict_search('type', user_config)
+            # PERLE - for now, if the config is empty (ie config.boot.default) for user type, assume adminstrator
+            if tmp == 'operator': command += f' --groups frr,frrvty,vyattaop,sudo,adm,dip,disk,_kea {user}'
+            else: command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea {user}'
             try:
                 cmd(command)
                 # we should not rely on the value stored in user_config['home_directory'], as a


### PR DESCRIPTION
Added a new vyos CLI local user type (privilege) setting to allow configuring local users to have restricted operator (linux commands are prohibited) or administrator level access (operator + config + linux commands).  The internal operator group is vyattaop and the administrator group uses vyattacfg.  The new config option assigns the user to either one.   Currently external authentication methods run a custom shell in the /etc/passwd since the users do not exist locally.
