### PR TITLE
N12006:9999 - added back check for non-existence of /opt/vyatta/etc/config.boot.default before installing model specific default config and removing unwanted CLI config node paths to run once only from default system

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -134,6 +134,11 @@ unmount_encrypted_config() {
 # if necessary, provide initial config and remove nodes by product and model
 init_prod_model_bootfile_and_nodes () {
 
+    # check if config.boot.default exists 
+    if [ -e $DEFAULT_BOOTFILE ]; then
+        return
+    fi
+
     # Scan /proc/cmdline for the token 'prod_id=IOLAN|IRG|IT' and extract the model-string
     prod_string=$(grep -oP '(?<=prod_id=)[^\s]+' /proc/cmdline)
 


### PR DESCRIPTION
Only run the logic to install the model specific default config and CLI node removal once from factory default.  