### PR TITLE
Enable IPv6 on wwan0

### DIFF
--- a/src/etc/sysctl.d/31-vyos-addr_gen_mode-wwan0.conf
+++ b/src/etc/sysctl.d/31-vyos-addr_gen_mode-wwan0.conf
@@ -1,0 +1,31 @@
+### Added by PSL in vyos-1x ###
+#
+# VyOS sets addr_gen_mode to 1 (do not generate link-local) for *ALL*
+# interfaces in case it is going to be added to a bridge, in which case
+# it must not have any addresses.  However, cellular gets these from the
+# provider and hence can never be in a bridge so this is not approriate.
+# The values are documented in Documentation/networking/ip-sysctl.txt
+#
+#   addr_gen_mode = 3
+#       0: generate address based on EUI64 (default)
+#       1: do no generate a link-local address, use EUI64 for addresses
+#          generated from autoconf
+#       2: generate stable privacy addresses, using the secret from
+#          stable_secret (RFC7217)
+#       3: generate stable privacy addresses, using a random secret if unset
+#
+# Note: router_project commit b28e9e875da also set these so that wwanmgr
+# can query the module and set the prefix/addr directly on the interface.
+# We do not need to do this.
+#
+#   router_solicitations = 0
+#       n: how many to send (default 3)
+#       
+#   accept_ra = 0
+#       0: Do not accept Router Advertisements.
+#       1: Accept Router Advertisements if forwarding is disabled.
+#       2: Overrule forwarding behavior
+
+net.ipv6.conf.wwan0.addr_gen_mode = 3
+#net.ipv6.conf.wwan0.router_solicitations = 0
+#net.ipv6.conf.wwan0.accept_ra = 0


### PR DESCRIPTION
VyOS sets addr_gen_mode to 1 (do not generate link-local) for *ALL*
interfaces in case it is going to be added to a bridge, in which case
it must not have any addresses.  However, cellular gets these from the
provider and hence can never be in a bridge so this is not approriate.

Normally this would be done via NetworkManager but VyOS does not use that.
So we do it via a sysctl overriding their existing 31-vyos-addr_gen_mode.conf
but for the wwan0 interface only.
