### PR TITLE
Fix for NXP wifi MAC addresses.

### DIFF
--- a/python/vyos/utils/nxpwifiutils.py
+++ b/python/vyos/utils/nxpwifiutils.py
@@ -1,0 +1,161 @@
+'''
+NXP Wifi related utilities.
+'''
+
+import os
+import subprocess
+import re
+
+
+def pcie_wifi_nxp_model() -> str:
+    '''
+    Returns NXP wifi PCIE model if one is installed, else ""
+
+    This corresponds to the base section value in the config file
+    /lib/firmware/nxp/wifi_mod_para.conf
+    '''
+    nxpmodel = ''
+    if not os.path.exists('/sys/module/moal'):
+        return nxpmodel  # Not using NXP at all
+
+    # Get NXP wifi devices on PCI
+    ret = subprocess.run(['lspci', '-vmm'], stdout=subprocess.PIPE)
+    for i in ret.stdout.decode().split('\n'):
+        if not i:
+            continue
+        tag, val = i.split(sep='\t', maxsplit=1)
+        if tag != 'Device:':
+            continue
+        if 'NXP' not in val or 'Wi-Fi' not in val:
+            continue
+
+        # NXP wifi device.  Get the 4-digit model.
+        m = re.match(r'.* [0-9][0-9][A-Z]([0-9]{4}).*', val)
+        if m:
+            try:
+                nxpmodel = 'PCIE' + m.groups()[0]
+                break
+            except Exception:
+                pass
+
+    return nxpmodel
+
+
+class NxpConf:
+    '''
+    NXP /lib/firmware/nxp/*.conf parser.
+
+    The format is just:
+
+    section = {
+        foo = 42
+        bar = baz
+    }
+    '''
+    def __init__(self, path: str):
+        self.path = path
+
+    def parse(self) -> dict[str, dict]:
+        '''Do the parse'''
+        sectdict: dict[str, dict] = {}
+        lineno = 0
+        cursect: dict[str, str] = {}
+        sectname = ''
+        with open(self.path) as fp:
+            for i in fp.readlines():
+                lineno += 1
+                i = i.strip()
+                if not i or i.startswith('#'):
+                    continue
+
+                if not sectname:
+                    # Section start "foo = {" expected
+                    try:
+                        sectname, _, brace = i.split(maxsplit=2)
+                        if not brace.startswith('{'):
+                            raise ValueError('Opening brace expected')
+                    except ValueError:
+                        raise ValueError('Expected "name = {" at line '
+                                         f'{lineno}: {i}') from None
+                    cursect = {}
+                elif i == '}':
+                    # End section
+                    sectdict[sectname] = cursect
+                    sectname, cursect = '', {}
+                else:
+                    # Inside a section
+                    try:
+                        name, val = i.split('=', 1)
+                    except ValueError:
+                        raise ValueError(f'Expected "name = val" at line '
+                                         f'{lineno} in section {sectname}: '
+                                         f'{i}') from None
+                    cursect[name] = val
+
+        return sectdict
+
+
+def getphymac(wifi: dict) -> str:
+    '''
+    PSL: Get preferred MAC for phy if none provided by VyOS config.
+
+    MACs cannot be programmed into some NXP devices.
+    Rather than falling back to the default hardware
+    /sys/class/ieee80211/*/addresses as VyOS normally does,
+    use either any supplied module configuration value from
+    /lib/firmware/nxp/wifi_mod_para.conf or else fall back to
+    the existing interface address.
+
+    For module configuration we are looking for config lines of the form:
+
+    PCIE9098_0 = {
+        ...
+        mac_addr=00:40:02:01:02:03
+        ...
+    }
+
+    ...for both PCIE9098_0 and PCIE9098_1 sections or however many phys
+    the device has, in this case for a PCIE9098 card, but it can be
+    any NXP model.
+
+    NOTE: This function returns '' if we are not equipped with an
+    NXP like device. VyOS will use the hardware address as usual.
+
+    NOTE: generate() below masks off the lower 4 bits and rebuilds them,
+    so the results will look a bit different than you might expect.
+    '''
+
+    hwmac = ''
+    if 'mac' in wifi:
+        # VyOS defined MAC already supplied
+        return hwmac
+
+    nxp_model = pcie_wifi_nxp_model()
+    if not nxp_model:
+        # Not NXP hardware so nothing to do
+        return hwmac
+
+    # Try NXP config file mac_addr
+    try:
+        nxpconf = NxpConf('/lib/firmware/nxp/wifi_mod_para.conf')
+        nxpconfd = nxpconf.parse()
+        phynum = wifi.get('physical_device', '0')[-1]
+        ifc = f'{nxp_model}_{phynum}'
+        hwmac = nxpconfd[ifc]['mac_addr']
+    except Exception:
+        pass
+
+    if not hwmac:
+        # Get mac from existing iface value instead
+        import subprocess
+        try:
+            ret = subprocess.run(['ip', '-json', '-detail', 'link',
+                                  'list', 'dev', wifi['ifname']],
+                                 stdout=subprocess.PIPE)
+            import json
+            j = json.loads(ret.stdout.decode().strip())
+            hwmac = j[0]['address']
+        except Exception:
+            pass
+
+    return hwmac

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -40,6 +40,7 @@ from vyos.utils.process import is_systemd_service_running
 from vyos.utils.network import interface_exists
 from vyos import ConfigError
 from vyos import airbag
+import vyos.utils.nxpwifiutils as nxpwifiutils
 airbag.enable()
 
 # XXX: wpa_supplicant works on the source interface
@@ -153,7 +154,7 @@ def verify(wifi):
     if 'ssid' not in wifi and wifi['type'] != 'monitor':
         raise ConfigError('SSID must be configured unless type is set to "monitor"!')
 
-    if os.access('/sys/module/moal', os.F_OK):
+    if '9098' in nxpwifiutils.pcie_wifi_nxp_model():
         # PSL: NXP 88W9098 wifi restrictions
         ifname = wifi.get('ifname', '')
         mode = wifi.get('mode', '')
@@ -259,6 +260,7 @@ def verify(wifi):
 
     return None
 
+
 def generate(wifi):
     check_kmod('mac80211')
 
@@ -280,24 +282,26 @@ def generate(wifi):
     if 'mac' not in wifi:
         # http://wiki.stocksy.co.uk/wiki/Multiple_SSIDs_with_hostapd
         # generate locally administered MAC address from used phy interface
-        with open('/sys/class/ieee80211/{physical_device}/addresses'.format(**wifi), 'r') as f:
-            # some PHYs tend to have multiple interfaces and thus supply multiple MAC
-            # addresses - we only need the first one for our calculation
-            tmp = f.readline().rstrip()
-            tmp = EUI(tmp).value
-            # mask last nibble from the MAC address
-            tmp &= 0xfffffffffff0
-            # set locally administered bit in MAC address
-            tmp |= 0x020000000000
-            # we now need to add an offset to our MAC address indicating this
-            # subinterfaces index
-            tmp += int(findall(r'\d+', interface)[0])
+        tmp = nxpwifiutils.getphymac(wifi)  # PSL: get preferred MAC
+        if not tmp:
+            with open('/sys/class/ieee80211/{physical_device}/addresses'.format(**wifi), 'r') as f:
+                # some PHYs tend to have multiple interfaces and thus supply multiple MAC
+                # addresses - we only need the first one for our calculation
+                tmp = f.readline().rstrip()
+        tmp = EUI(tmp).value
+        # mask last nibble from the MAC address
+        tmp &= 0xfffffffffff0
+        # set locally administered bit in MAC address
+        tmp |= 0x020000000000
+        # we now need to add an offset to our MAC address indicating this
+        # subinterfaces index
+        tmp += int(findall(r'\d+', interface)[0])
 
-            # convert integer to "real" MAC address representation
-            mac = EUI(hex(tmp).split('x')[-1])
-            # change dialect to use : as delimiter instead of -
-            mac.dialect = mac_unix_expanded
-            wifi['mac'] = str(mac)
+        # convert integer to "real" MAC address representation
+        mac = EUI(hex(tmp).split('x')[-1])
+        # change dialect to use : as delimiter instead of -
+        mac.dialect = mac_unix_expanded
+        wifi['mac'] = str(mac)
 
     # render appropriate new config files depending on access-point or station mode
     if wifi['type'] == 'access-point':


### PR DESCRIPTION
1. Add support for setting your own MAC addresses.
   Update /lib/firmware/nxp/wifi_mod_para.conf like this:

    PCIE9098_0 = {
        ...
        mac_addr=00:40:02:01:02:03
        ...
    }
    PCIE9098_1 = {
        ...
        mac_addr=00:40:02:04:05:06
        ...
    }

2. Make CLI wifi restrictions from a few months back
   specifically dependent on the 9098 card being present.
   Restrictions for other cards can be added as needed.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
