### PR TITLE
Ssh tpm

### DIFF
--- a/data/templates/ssh/sshd_config.j2
+++ b/data/templates/ssh/sshd_config.j2
@@ -6,9 +6,11 @@
 # Non-configurable defaults
 #
 Protocol 2
-HostKey /etc/ssh/ssh_host_rsa_key
+# PERLE - added
+Include /etc/ssh/sshd_config.d/*.conf
+# PERLE - removed HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
+# PERLE - removed HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 SyslogFacility AUTH
 LoginGraceTime 120

--- a/debian/control
+++ b/debian/control
@@ -236,6 +236,7 @@ Depends:
 # For "service ssh"
   openssh-server,
   sshguard,
+  ssh-tpm-agent,
 # End "service ssh"
 # For "service salt-minion"
   salt-minion,

--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -11,6 +11,7 @@ etc/ppp
 etc/securetty
 etc/security
 etc/skel
+etc/ssh/sshd_config.d
 etc/sudoers.d
 etc/systemd
 etc/sysctl.d

--- a/src/conf_mode/service_ssh.py
+++ b/src/conf_mode/service_ssh.py
@@ -47,6 +47,10 @@ sshguard_whitelist = '/etc/sshguard/whitelist'
 key_rsa = '/etc/ssh/ssh_host_rsa_key'
 key_dsa = '/etc/ssh/ssh_host_dsa_key'
 key_ed25519 = '/etc/ssh/ssh_host_ed25519_key'
+# PERLE added tpm backed keys
+key_ecdsa = '/etc/ssh/ssh_host_ecdsa_key'
+tpm_key_rsa = '/etc/ssh/ssh_tpm_host_rsa_key.tpm'
+tpm_key_ecdsa = '/etc/ssh/ssh_tpm_host_ecdsa_key.tpm'
 
 trusted_user_ca = config_files['sshd_user_ca']
 
@@ -129,15 +133,30 @@ def generate(ssh):
 
     # This usually happens only once on a fresh system, SSH keys need to be
     # freshly generted, one per every system!
-    if not os.path.isfile(key_rsa):
-        syslog(LOG_INFO, 'SSH RSA host key not found, generating new key!')
-        call(f'ssh-keygen -q -N "" -t rsa -f {key_rsa}')
+    # PERLE removed generating RSA server host key text files
+    # PERLE if not os.path.isfile(key_rsa):
+        # PERLE modified syslog(LOG_INFO, 'SSH RSA host key not found, generating new key!')
+        # PERLE modified call(f'ssh-keygen -q -N "" -t rsa -f {key_rsa}')
     if not os.path.isfile(key_dsa):
         syslog(LOG_INFO, 'SSH DSA host key not found, generating new key!')
         call(f'ssh-keygen -q -N "" -t dsa -f {key_dsa}')
     if not os.path.isfile(key_ed25519):
         syslog(LOG_INFO, 'SSH ed25519 host key not found, generating new key!')
         call(f'ssh-keygen -q -N "" -t ed25519 -f {key_ed25519}')
+    # PERLE added - sudo to remove old rsa/ecdsa files, then create tpm backed rsa  ecdsa keys
+    if os.path.isfile(key_rsa):
+        syslog(LOG_INFO, 'SSH RSA host key found, removing text key file')
+        call(f'sudo rm {key_rsa}*')
+    if os.path.isfile(key_ecdsa):
+        syslog(LOG_INFO, 'SSH ECDSA host key found, removing text key file!')
+        call(f'sudo rm {key_ecdsa}*')
+    if not os.path.isfile(tpm_key_rsa):
+        syslog(LOG_INFO, 'SSH tpm backed RSA host key not found, generating new key!')
+        call(f'ssh-tpm-keygen -A')
+        call(f'ssh-tpm-hostkeys --install-system-units')
+    if not os.path.isfile(tpm_key_ecdsa):
+        syslog(LOG_INFO, 'SSH tpm backed ECDSA host key not found, generating new key!')
+        call(f'ssh-tpm-keygen -A')
 
     if 'trusted_user_ca' in ssh:
         key_name = ssh['trusted_user_ca']
@@ -173,6 +192,9 @@ def apply(ssh):
         # SSH access is removed in the commit
         call('systemctl stop ssh@*.service')
         call(f'systemctl stop {systemd_service_sshguard}')
+        # PERLE added
+        call(f'systemctl stop ssh-tpm-service')
+        call(f'systemctl stop ssh-tpm-service.socket')
         return None
 
     if 'dynamic_protection' not in ssh:
@@ -187,6 +209,11 @@ def apply(ssh):
         # stop all VRF services and only restart then new ones
         call('systemctl stop ssh@*.service')
         systemd_action = 'restart'
+
+    # PERLE added
+    # call(f'systemctl enable --now ssh-tpm-agent.socket')
+    call(f'systemctl {systemd_action} ssh-tpm-agent')
+    call(f'systemctl {systemd_action} ssh-tpm-agent.socket')
 
     for vrf in ssh['vrf']:
         call(f'systemctl {systemd_action} ssh@{vrf}.service')

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -465,7 +465,8 @@ def apply(login):
             else: command += f" --home '/home/{user}'"
 
             if 'operator' not in user_config:
-                command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea'
+            # PERLE - support for TPM - add tss group 
+                command += f' --groups frr,frrvty,tss,vyattacfg,sudo,adm,dip,disk,_kea'
 
             command += f' {user}'
 

--- a/src/etc/ssh/sshd_config.d/10-ssh-tpm-agent.conf
+++ b/src/etc/ssh/sshd_config.d/10-ssh-tpm-agent.conf
@@ -1,0 +1,3 @@
+HostKeyAgent /var/tmp/ssh-tpm-agent.sock
+HostKey /etc/ssh/ssh_tpm_host_ecdsa_key.pub
+HostKey /etc/ssh/ssh_tpm_host_rsa_key.pub

--- a/src/op_mode/generate_ssh_server_key.py
+++ b/src/op_mode/generate_ssh_server_key.py
@@ -30,6 +30,19 @@ if commit_in_progress():
 
 conf_mode_dir = directories['conf_mode']
 
-cmd('rm -v /etc/ssh/ssh_host_*')
-cmd('dpkg-reconfigure openssh-server')
+# PERLE - vyos changed to call service_ssh.py, but we need to still remove the .tpm tss2 files
+# cmd('rm -v /etc/ssh/ssh_host_*')
+# cmd('dpkg-reconfigure openssh-server')
+
+cmd('sudo rm -v /etc/ssh/ssh_host_* || true')
+cmd('sudo rm -v /etc/ssh/ssh_tpm_host_* || true')
+
+# cmd('ssh-tpm-keygen -A')
+# cmd('ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key')
+# cmd('ssh-keygen -q -N "" -t ed25519 -f /etc/ssh/ssh_host_ed25519_key')
+
 cmd(f'{conf_mode_dir}/service_ssh.py')
+
+# PERLE - restart of the tpm key agent now called from logic in service_ssh.py 
+# cmd('systemctl restart ssh-tpm-agent')
+# cmd('systemctl restart ssh-tpm-agent.socket')


### PR DESCRIPTION
To avoid patching openssh. we use a non debian ssh agent package ssh-tpm-agent that provides binaries for creating, importing and interfacing with sshd to provide rsa2048 and ecdsa 256/384/512 nist hostkeys.  These keys are stored as sealed TSS2 private key and .pub key text files under /etc/ssh, but the TSS2 key file is sealed using the processor's HUK and cannot be used outside of a particular unit.  We leave the clear text ED25519 and DSA keys as options so we can support a wider range of client key algorthms.  Vyos-1x supports op-mode generate ssh server-keys and conf-mode ssh commands that need to start/restart the ssh-tpm-agent service, regenerate the tpm backed host keys and to include the new config options to communicated with the new agent
