### PR TITLE
SSHD import hostkey CLI command

### DIFF
--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -480,6 +480,81 @@
               </tagNode>
             </children>
           </node>
+          <node name="ssh-server-key">
+            <properties>
+              <help>Import ssh server host key files into TPM backed TSS2 format</help>
+            </properties>
+            <children>
+              <node name="type">
+                <properties>
+                   <help>SSH server hostkey type</help>
+                </properties>
+                <children>
+                  <node name="ssh-rsa">
+                    <properties>
+                       <help>SSH server hostkey type RSA</help>
+                    </properties>
+                    <children>
+                      <tagNode name="key-file">
+                        <properties>
+                           <help>Path to SSH server hostkey files: key-filename and key-filename.pub</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_rsa_key" --filename "$7"</command>
+                      </tagNode>
+                    </children>
+                  </node>
+                  <node name="ssh-ecdsa">
+                    <properties>
+                       <help>SSH server hostkey type ECDSA</help>
+                    </properties>
+                    <children>
+                      <tagNode name="key-file">
+                        <properties>
+                           <help>Path to SSH server hostkey files: name and name.pub</help>
+                           <completionHelp>
+                             <list>&lt;name&gt;</list>
+                           </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_ecdsa_key" --filename "$7"</command>
+                      </tagNode>
+                    </children>
+                  </node>
+                  <node name="ssh-dsa">
+                    <properties>
+                       <help>SSH server hostkey type DSA</help>
+                    </properties>
+                    <children>
+                      <tagNode name="key-file">
+                        <properties>
+                           <help>Path to SSH server hostkey files: name and name.pub</help>
+                           <completionHelp>
+                             <list>&lt;name&gt;</list>
+                           </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_dsa_key" --filename "$7"</command>
+                      </tagNode>
+                    </children>
+                  </node>
+                  <node name="ssh-ed25519">
+                    <properties>
+                       <help>SSH server hostkey type ED25519</help>
+                    </properties>
+                    <children>
+                      <tagNode name="key-file">
+                        <properties>
+                           <help>Path to SSH server hostkey files: name and name.pub</help>
+                           <completionHelp>
+                             <list>&lt;name&gt;</list>
+                           </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_ed25519_key" --filename "$7"</command>
+                      </tagNode>
+                    </children>
+                  </node>
+                </children>
+              </node>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1108,7 +1108,7 @@ def import_ssh_hostkey(name, path):
 
     conf_mode_dir = directories['conf_mode']
     destination = f"/etc/ssh/{name}"
-    destination2 = destination + ".pub" 
+    destination2 = destination + ".pub"
 
     if name == 'ssh_host_rsa_key':
         if os.system(f"grep -q 'ssh-rsa' '{path2}'") != 0:
@@ -1117,7 +1117,7 @@ def import_ssh_hostkey(name, path):
         print(f'Importing SSH RSA server host key: {path} to tpm TSS2 format: /etc/ssh/ssh_tpm_host_rsa.tpm')
         os.system(f"sudo cp '{path2}' /etc/ssh/ssh_tpm_host_rsa_key.pub")
         os.system(f"sudo ssh-tpm-keygen --import '{path}' -t rsa -f /etc/ssh/ssh_tpm_host_rsa_key")
-        os.system(f"sudo systemctl restart ssh-tpm-agent")
+        os.system("sudo systemctl restart ssh-tpm-agent")
     elif name == 'ssh_host_ecdsa_key':
         if os.system(f"grep -q 'ecdsa-sha' '{path2}'") != 0:
             print(f'Error: SSH server host public key file: {path2} is not ssh-ecdsa format')
@@ -1125,12 +1125,12 @@ def import_ssh_hostkey(name, path):
         print(f'Importing SSH ECDSA server host key: {path} to tpm TSS2 format: /etc/ssh/ssh_tpm_host_ecdsa.tpm')
         os.system(f"sudo cp '{path2}' /etc/ssh/ssh_tpm_host_ecdsa_key.pub")
         os.system(f"sudo ssh-tpm-keygen --import '{path}' -t ecdsa -f /etc/ssh/ssh_tpm_host_ecdsa_key")
-        os.system(f"sudo systemctl restart ssh-tpm-agent")
+        os.system("sudo systemctl restart ssh-tpm-agent")
     elif name == 'ssh_host_dsa_key':
         if os.system(f"grep -q 'ssh-dss' '{path2}'") != 0:
             print(f'Error: SSH server host public key file: {path2} is not ssh-dsa format')
             return
-        print(f'Warning: DSA TSS2 format is not supported.')
+        print('Warning: DSA TSS2 format is not supported.')
         print(f'Copying SSH DSA server host key: {path} to {destination}')
         os.system(f"sudo cp '{path}' '{destination}'")
         os.system(f"sudo cp '{path2}' '{destination2}'")
@@ -1139,7 +1139,7 @@ def import_ssh_hostkey(name, path):
         if os.system(f"grep -q 'ssh-ed25519' '{path2}'") != 0:
             print(f'Error: SSH server host public key file: {path2} is not ssh-ed25519 format')
             return
-        print(f'Warning: ED25519 TSS2 format is not supported.')
+        print('Warning: ED25519 TSS2 format is not supported.')
         print(f'Copying SSH ED25519 server host key: {path} to {destination}')
         os.system(f"sudo cp '{path}' '{destination}'")
         os.system(f"sudo cp '{path2}' '{destination2}'")

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1107,6 +1107,8 @@ def import_ssh_hostkey(name, path):
         return
 
     conf_mode_dir = directories['conf_mode']
+    destination = f"/etc/ssh/{name}"
+    destination2 = destination + ".pub" 
 
     if name == 'ssh_host_rsa_key':
         if os.system(f"grep -q 'ssh-rsa' '{path2}'") != 0:
@@ -1128,8 +1130,6 @@ def import_ssh_hostkey(name, path):
         if os.system(f"grep -q 'ssh-dss' '{path2}'") != 0:
             print(f'Error: SSH server host public key file: {path2} is not ssh-dsa format')
             return
-        destination = f"/etc/ssh/{name}"
-        destination2 = destination + ".pub" 
         print(f'Warning: DSA TSS2 format is not supported.')
         print(f'Copying SSH DSA server host key: {path} to {destination}')
         os.system(f"sudo cp '{path}' '{destination}'")
@@ -1139,8 +1139,6 @@ def import_ssh_hostkey(name, path):
         if os.system(f"grep -q 'ssh-ed25519' '{path2}'") != 0:
             print(f'Error: SSH server host public key file: {path2} is not ssh-ed25519 format')
             return
-        destination = f"/etc/ssh/{name}"
-        destination2 = destination + ".pub" 
         print(f'Warning: ED25519 TSS2 format is not supported.')
         print(f'Copying SSH ED25519 server host key: {path} to {destination}')
         os.system(f"sudo cp '{path}' '{destination}'")

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -26,6 +26,8 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 
 import vyos.opmode
 
+# PERLE - add access to config directory for invoking service_ssh.py
+from vyos.defaults import directories
 from vyos.config import Config
 from vyos.config import config_dict_mangle_acme
 from vyos.pki import encode_certificate
@@ -53,7 +55,8 @@ from vyos.utils.process import cmd
 CERT_REQ_END = '-----END CERTIFICATE REQUEST-----'
 auth_dir = '/config/auth'
 
-ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl']
+# PERLE add ssh hostkey option
+ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl', 'ssh-hostkey']
 ArgsPkiTypeGen = typing.Literal[ArgsPkiType, typing.Literal['ssh', 'wireguard']]
 ArgsFingerprint = typing.Literal['sha256', 'sha384', 'sha512']
 
@@ -1088,6 +1091,64 @@ def import_openvpn_secret(name, path):
 
     install_openvpn_key(name, key_data, key_version)
 
+# PERLE - add support for importing ssh host keys from existing ssh private and public key files
+#         into the standard /etc/ssh/ssh_tpm_host_xxx_key.tpm/pub. Valid only for RSA and ECDSA
+
+def import_ssh_hostkey(name, path):
+
+    if not os.path.exists(path):
+        print(f'SSH server host private key file not found: {path}')
+        return
+
+    path2 = path + ".pub"
+
+    if not os.path.exists(path2):
+        print(f'Corresponding SSH server host public key file not found: {path2}')
+        return
+
+    conf_mode_dir = directories['conf_mode']
+
+    if name == 'ssh_host_rsa_key':
+        if os.system(f"grep -q 'ssh-rsa' '{path2}'") != 0:
+            print(f'Error: SSH server host public key file: {path2} is not ssh-rsa format')
+            return
+        print(f'Importing SSH RSA server host key: {path} to tpm TSS2 format: /etc/ssh/ssh_tpm_host_rsa.tpm')
+        os.system(f"sudo cp '{path2}' /etc/ssh/ssh_tpm_host_rsa_key.pub")
+        os.system(f"sudo ssh-tpm-keygen --import '{path}' -t rsa -f /etc/ssh/ssh_tpm_host_rsa_key")
+        os.system(f"sudo systemctl restart ssh-tpm-agent")
+    elif name == 'ssh_host_ecdsa_key':
+        if os.system(f"grep -q 'ecdsa-sha' '{path2}'") != 0:
+            print(f'Error: SSH server host public key file: {path2} is not ssh-ecdsa format')
+            return
+        print(f'Importing SSH ECDSA server host key: {path} to tpm TSS2 format: /etc/ssh/ssh_tpm_host_ecdsa.tpm')
+        os.system(f"sudo cp '{path2}' /etc/ssh/ssh_tpm_host_ecdsa_key.pub")
+        os.system(f"sudo ssh-tpm-keygen --import '{path}' -t ecdsa -f /etc/ssh/ssh_tpm_host_ecdsa_key")
+        os.system(f"sudo systemctl restart ssh-tpm-agent")
+    elif name == 'ssh_host_dsa_key':
+        if os.system(f"grep -q 'ssh-dss' '{path2}'") != 0:
+            print(f'Error: SSH server host public key file: {path2} is not ssh-dsa format')
+            return
+        destination = f"/etc/ssh/{name}"
+        destination2 = destination + ".pub" 
+        print(f'Warning: DSA TSS2 format is not supported.')
+        print(f'Copying SSH DSA server host key: {path} to {destination}')
+        os.system(f"sudo cp '{path}' '{destination}'")
+        os.system(f"sudo cp '{path2}' '{destination2}'")
+        cmd(f'{conf_mode_dir}/service_ssh.py')
+    elif name == 'ssh_host_ed25519_key':
+        if os.system(f"grep -q 'ssh-ed25519' '{path2}'") != 0:
+            print(f'Error: SSH server host public key file: {path2} is not ssh-ed25519 format')
+            return
+        destination = f"/etc/ssh/{name}"
+        destination2 = destination + ".pub" 
+        print(f'Warning: ED25519 TSS2 format is not supported.')
+        print(f'Copying SSH ED25519 server host key: {path} to {destination}')
+        os.system(f"sudo cp '{path}' '{destination}'")
+        os.system(f"sudo cp '{path2}' '{destination2}'")
+        cmd(f'{conf_mode_dir}/service_ssh.py')
+    else:
+        print('Error: invalid ssh server key type')
+
 
 def generate_pki(
     raw: bool,
@@ -1184,6 +1245,8 @@ def import_pki(
             )
         elif pki_type == 'openvpn':
             import_openvpn_secret(name, filename)
+        elif pki_type == 'ssh-hostkey':
+            import_ssh_hostkey(name, filename)
     except KeyboardInterrupt:
         print('Aborted')
         sys.exit(0)


### PR DESCRIPTION
VYOS does not have a CLI that allows SSHD hostkeys to be imported and used as the default hostkeys.  It assumes the user will use linux commands like scp, https, etc to download ssh-keygen key files onto the unit and copy/rename those files to the default hostkeys under /etc/ssh.  Now that we generate/use TPM2 backed sshd hostkeys for RSA and ECDSA, we need a CLI that would automate/help importing normal RSA/ECDSA host key files, import them to TSS2 tpm-backed format using ssh-tpm-keygen and restart the ssh-tpm-agent to use the updated default TSS2 hostkey.  For ED25519 and DSA hostkeys, the new CLI would just copy them to the /etc/ssh/ssh_host_xxx_key and .pub files and restart the SSHD service.  It would be nice in the future to support an import + copy and paste version of the CLI for private-key and public-key and save it as proper ssh-keygen format RAM files, and import to ssh-tpm-keygen TSS2 format and remove the RAM key files for RSA/ECDSA.  For DSA and ED25519, the RAM files would overwrite existing /etc/ssh/ssh_host_xxxx_key files