### PR TITLE
Op mode ssh host key import via copy/paste

### DIFF
--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -495,9 +495,26 @@
                        <help>SSH server hostkey type RSA</help>
                     </properties>
                     <children>
+                      <tagNode name="public-key">
+                        <properties>
+                          <help>SSH server public hostkey</help>
+                        </properties>
+                        <children>
+                          <leafNode name="key">
+                            <properties>
+                              <help>Private key in PEM format</help>
+                              <constraint>
+                                <validator name="base64"/>
+                              </constraint>
+                              <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt --name "ssh_host_rsa_key" --key-filename "$8"</command>
+                          </leafNode>
+                        </children>
+                      </tagNode>
                       <tagNode name="key-file">
                         <properties>
-                           <help>Path to SSH server hostkey files: key-filename and key-filename.pub</help>
+                           <help>Path to SSH server hostkey files: key-filename and key-filename.pub ***TEST** REMOVE</help>
                         </properties>
                         <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_rsa_key" --filename "$7"</command>
                       </tagNode>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -503,7 +503,17 @@
                           </constraint>
                           <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
                         </properties>
-                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt --name "ssh_host_rsa_key" --key-txt "$7"</command>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-pub --name "ssh_host_rsa_key" --key-txt "$7"</command>
+                      </tagNode>
+                      <tagNode name="private-key">
+                        <properties>
+                          <help>Private key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-priv --name "ssh_host_rsa_key" --key-txt "$7"</command>
                       </tagNode>
                       <tagNode name="key-file">
                         <properties>
@@ -518,6 +528,26 @@
                        <help>SSH server hostkey type ECDSA</help>
                     </properties>
                     <children>
+                      <tagNode name="public-key">
+                        <properties>
+                          <help>Public key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-pub --name "ssh_host_ecdsa_key" --key-txt "$7"</command>
+                      </tagNode>
+                      <tagNode name="private-key">
+                        <properties>
+                          <help>Private key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-priv --name "ssh_host_ecdsa_key" --key-txt "$7"</command>
+                      </tagNode>
                       <tagNode name="key-file">
                         <properties>
                            <help>Path to SSH server hostkey files: name and name.pub</help>
@@ -534,6 +564,26 @@
                        <help>SSH server hostkey type DSA</help>
                     </properties>
                     <children>
+                      <tagNode name="public-key">
+                        <properties>
+                          <help>Public key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-pub --name "ssh_host_dsa_key" --key-txt "$7"</command>
+                      </tagNode>
+                      <tagNode name="private-key">
+                        <properties>
+                          <help>Private key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-priv --name "ssh_host_dsa_key" --key-txt "$7"</command>
+                      </tagNode>
                       <tagNode name="key-file">
                         <properties>
                            <help>Path to SSH server hostkey files: name and name.pub</help>
@@ -550,6 +600,26 @@
                        <help>SSH server hostkey type ED25519</help>
                     </properties>
                     <children>
+                      <tagNode name="public-key">
+                        <properties>
+                          <help>Public key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-pub --name "ssh_host_ed25519_key" --key-txt "$7"</command>
+                      </tagNode>
+                      <tagNode name="private-key">
+                        <properties>
+                          <help>Private key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt-priv --name "ssh_host_ed25519_key" --key-txt "$7"</command>
+                      </tagNode>
                       <tagNode name="key-file">
                         <properties>
                            <help>Path to SSH server hostkey files: name and name.pub</help>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -497,24 +497,17 @@
                     <children>
                       <tagNode name="public-key">
                         <properties>
-                          <help>SSH server public hostkey</help>
+                          <help>Public key without headers and footers</help>
+                          <constraint>
+                            <validator name="base64"/>
+                          </constraint>
+                          <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
                         </properties>
-                        <children>
-                          <leafNode name="key">
-                            <properties>
-                              <help>Private key in PEM format</help>
-                              <constraint>
-                                <validator name="base64"/>
-                              </constraint>
-                              <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
-                            </properties>
-                            <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt --name "ssh_host_rsa_key" --key-filename "$8"</command>
-                          </leafNode>
-                        </children>
+                        <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey-txt --name "ssh_host_rsa_key" --key-txt "$7"</command>
                       </tagNode>
                       <tagNode name="key-file">
                         <properties>
-                           <help>Path to SSH server hostkey files: key-filename and key-filename.pub ***TEST** REMOVE</help>
+                           <help>Path to SSH server hostkey files: key-filename and key-filename.pub</help>
                         </properties>
                         <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ssh-hostkey --name "ssh_host_rsa_key" --filename "$7"</command>
                       </tagNode>

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1337,12 +1337,8 @@ def import_pki(
         elif pki_type == 'ssh-hostkey': # add handling for importing ssh host keys via copypaste import
             import_ssh_hostkey(name, filename)
         elif pki_type == 'ssh-hostkey-txt-pub':
-            print("got text input for ssh hostkey import")
-            print(name, key_txt)
             save_ssh_hostkey_txt(name, key_txt, "public")
         elif pki_type == 'ssh-hostkey-txt-priv':
-            print("got text input for ssh hostkey import")
-            print(name, key_txt)
             #check if public key exists in /tmp/{name}.pub
             pub_temp_filename = f'/tmp/{name}.pub'
             if not os.path.exists(pub_temp_filename):

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1203,6 +1203,96 @@ def generate_pki(
         print('Aborted')
         sys.exit(0)
 
+def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
+    """Save pasted SSH key text into appropriate temporary filename and format.
+
+    For public keys we expect the OpenSSH single-line public key (e.g. "ssh-rsa AAAAB3Nza...").
+    For private keys we accept either a PEM-like block or the OpenSSH private key format and write
+    it verbatim to the temp file. The import flow expects /tmp/{name} for the private key and
+    /tmp/{name}.pub for the public key.
+    """
+    temp_filename = f'/tmp/{name}'
+
+    # Validate supported names
+    supported = (
+        'ssh_host_rsa_key',
+        'ssh_host_ecdsa_key',
+        'ssh_host_dsa_key',
+        'ssh_host_ed25519_key',
+    )
+    if name not in supported:
+        print('Error: invalid ssh server key type for text import')
+        return
+
+    # Public key handling:
+    # - If the pasted text already looks like an OpenSSH public key (starts with "ssh-" or "ecdsa-" etc.),
+    #   write it directly to /tmp/{name}.pub
+    # - If the pasted text is just the base64 part, attempt to prefix with the conventional algorithm".
+    if type == 'public':
+        pub_path = temp_filename + '.pub'
+        txt = key_txt.strip()
+        # If already contains a space and starts with known prefixes, assume full OpenSSH public key
+        if txt.startswith('ssh-') or txt.startswith('ecdsa-') or txt.startswith('ecdsa-sha') or txt.startswith('ecdsa-sha2') or txt.startswith('ssh-dss') or txt.startswith('ssh-ed25519'):
+            pub_line = txt
+        else:
+            # Only the base64 body was provided. Prefix based on name.
+            if name == 'ssh_host_rsa_key':
+                pub_line = 'ssh-rsa ' + txt
+            elif name == 'ssh_host_ecdsa_key':
+                # Default to nistp256 curve identifier for ecdsa public key storage
+                pub_line = 'ecdsa-sha2-nistp256 ' + txt
+            elif name == 'ssh_host_dsa_key':
+                pub_line = 'ssh-dss ' + txt
+            elif name == 'ssh_host_ed25519_key':
+                pub_line = 'ssh-ed25519 ' + txt
+            else:
+                pub_line = txt
+
+        with open(pub_path, 'w') as temp_file:
+            temp_file.write(pub_line + '\n')
+
+        print(f'Wrote temp public key file: {pub_path}')
+        print('Now paste the corresponding private key text to complete the ssh hostkey import.')
+        return
+
+    # Private key handling:
+    if type == 'private':
+        priv_path = temp_filename
+        txt = key_txt.strip()
+        # If the text contains PEM markers assume it's a PEM/private-key block and write as-is
+        if txt.startswith('-----BEGIN'):
+            out_txt = txt + '\n' if not txt.endswith('\n') else txt
+        else:
+            # If the user pasted a single-line OpenSSH public key by mistake, warn
+            if txt.startswith('ssh-'):
+                print('Warning: pasted text looks like a public key, expected private key')
+                out_txt = txt + '\n'
+            else:
+                # If the pasted text looks like base64 only (no headers), try to wrap it into
+                # a PEM-like block based on the key type so import tools can parse it.
+                b64_body = ''.join(txt.split())
+                if re.fullmatch(r'[A-Za-z0-9+/=]+', b64_body):
+                    # Choose header/footer according to key name
+                    if name == 'ssh_host_rsa_key' or name == 'ssh_host_ecdsa_key' or name == 'ssh_host_dsa_key' or name == 'ssh_host_ed25519_key':
+                        # New OpenSSH private keys use the OPENSSH PRIVATE KEY wrapper
+                        header = '-----BEGIN OPENSSH PRIVATE KEY-----'
+                        footer = '-----END OPENSSH PRIVATE KEY-----'
+                    else:
+                        header = '-----BEGIN PRIVATE KEY-----'
+                        footer = '-----END PRIVATE KEY-----'
+
+                    # wrap lines at 64 chars
+                    wrapped = '\n'.join([b64_body[i:i+64] for i in range(0, len(b64_body), 64)])
+                    out_txt = header + '\n' + wrapped + '\n' + footer + '\n'
+                else:
+                    # Fallback: write verbatim
+                    out_txt = txt + '\n'
+
+        with open(priv_path, 'w') as temp_file:
+            temp_file.write(out_txt)
+
+        print(f'Wrote temp private key file: {priv_path}'))
+        return
 
 def import_pki(
     name: str,
@@ -1249,12 +1339,7 @@ def import_pki(
         elif pki_type == 'ssh-hostkey-txt-pub':
             print("got text input for ssh hostkey import")
             print(name, key_txt)
-            #write key_txt to a temp file and call import_ssh_hostkey with that temp file
-            temp_filename = f'/tmp/{name}.pub'
-            with open(temp_filename, 'w') as temp_file:
-                temp_file.write(key_txt)
-            print(f'Wrote temp public key file: {temp_filename}')
-            print(f'Now import the corresponding private key text to complete the ssh hostkey import.')
+            save_ssh_hostkey_txt(name, key_txt, "public")
         elif pki_type == 'ssh-hostkey-txt-priv':
             print("got text input for ssh hostkey import")
             print(name, key_txt)
@@ -1264,14 +1349,10 @@ def import_pki(
                 print(f'Corresponding SSH server host public key temp file not found: {pub_temp_filename}. Import Public Key then try again.')
                 return
             #write key_txt to a temp file and call import_ssh_hostkey with that temp file
-            temp_filename = f'/tmp/{name}'
-            with open(temp_filename, 'w') as temp_file:
-                temp_file.write(key_txt)
-            os.remove(temp_filename)
-            os.remove(pub_temp_filename)
-            import_ssh_hostkey(name, temp_filename)
-            print(f'Imported ssh hostkey: {name} from text input.')
-            print('Completed ssh hostkey import.')
+            save_ssh_hostkey_txt(name, key_txt, "private")
+            import_ssh_hostkey(name, f'/tmp/{name}')
+            os.remove(f'/tmp/{name}')
+            os.remove(f'/tmp/{name}' + '.pub')
 
 
     except KeyboardInterrupt:

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -55,7 +55,7 @@ CERT_REQ_END = '-----END CERTIFICATE REQUEST-----'
 auth_dir = '/config/auth'
 
 # PERLE add ssh hostkey option
-ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl', 'ssh-hostkey']
+ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl', 'ssh-hostkey', 'ssh-hostkey-txt']
 ArgsPkiTypeGen = typing.Literal[ArgsPkiType, typing.Literal['ssh', 'wireguard']]
 ArgsFingerprint = typing.Literal['sha256', 'sha384', 'sha512']
 
@@ -1243,8 +1243,14 @@ def import_pki(
             )
         elif pki_type == 'openvpn':
             import_openvpn_secret(name, filename)
-        elif pki_type == 'ssh-hostkey':
+        elif pki_type == 'ssh-hostkey': # add handling for importing ssh host keys via copypaste import
             import_ssh_hostkey(name, filename)
+        elif pki_type == 'ssh-hostkey-txt':
+            print("got text input for ssh hostkey import")
+            print(name, filename)
+            #import_ssh_hostkey(name, txt)
+
+
     except KeyboardInterrupt:
         print('Aborted')
         sys.exit(0)

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -55,7 +55,7 @@ CERT_REQ_END = '-----END CERTIFICATE REQUEST-----'
 auth_dir = '/config/auth'
 
 # PERLE add ssh hostkey option
-ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl', 'ssh-hostkey', 'ssh-hostkey-txt']
+ArgsPkiType = typing.Literal['ca', 'certificate', 'dh', 'key-pair', 'openvpn', 'crl', 'ssh-hostkey', 'ssh-hostkey-txt-pub', 'ssh-hostkey-txt-priv']
 ArgsPkiTypeGen = typing.Literal[ArgsPkiType, typing.Literal['ssh', 'wireguard']]
 ArgsFingerprint = typing.Literal['sha256', 'sha384', 'sha512']
 
@@ -1246,10 +1246,32 @@ def import_pki(
             import_openvpn_secret(name, filename)
         elif pki_type == 'ssh-hostkey': # add handling for importing ssh host keys via copypaste import
             import_ssh_hostkey(name, filename)
-        elif pki_type == 'ssh-hostkey-txt':
+        elif pki_type == 'ssh-hostkey-txt-pub':
             print("got text input for ssh hostkey import")
             print(name, key_txt)
-            #import_ssh_hostkey(name, txt)
+            #write key_txt to a temp file and call import_ssh_hostkey with that temp file
+            temp_filename = f'/tmp/{name}.pub'
+            with open(temp_filename, 'w') as temp_file:
+                temp_file.write(key_txt)
+            print(f'Wrote temp public key file: {temp_filename}')
+            print(f'Now import the corresponding private key text to complete the ssh hostkey import.')
+        elif pki_type == 'ssh-hostkey-txt-priv':
+            print("got text input for ssh hostkey import")
+            print(name, key_txt)
+            #check if public key exists in /tmp/{name}.pub
+            pub_temp_filename = f'/tmp/{name}.pub'
+            if not os.path.exists(pub_temp_filename):
+                print(f'Corresponding SSH server host public key temp file not found: {pub_temp_filename}. Import Public Key then try again.')
+                return
+            #write key_txt to a temp file and call import_ssh_hostkey with that temp file
+            temp_filename = f'/tmp/{name}'
+            with open(temp_filename, 'w') as temp_file:
+                temp_file.write(key_txt)
+            os.remove(temp_filename)
+            os.remove(pub_temp_filename)
+            import_ssh_hostkey(name, temp_filename)
+            print(f'Imported ssh hostkey: {name} from text input.')
+            print('Completed ssh hostkey import.')
 
 
     except KeyboardInterrupt:

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1206,10 +1206,10 @@ def generate_pki(
 def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
     """Save pasted SSH key text into appropriate temporary filename and format.
 
-    For public keys we expect the OpenSSH single-line public key (e.g. "ssh-rsa AAAAB3Nza...").
-    For private keys we accept either a PEM-like block or the OpenSSH private key format and write
-    it verbatim to the temp file. The import flow expects /tmp/{name} for the private key and
-    /tmp/{name}.pub for the public key.
+    For public keys we expect the OpenSSH single-line public key (e.g. "ssh-rsa AAAAB3Nza..."). or just the base64 part.
+    We write it to /tmp/{name}.pub either verbatim or prefixed with the appropriate algorithm identifier.
+    For private keys we accept either a PEM-like block or base64 only. We wrap base64-only keys into a PEM-like block and attach header/footer
+    according to the key type, or write it verbatim to the temp file.
     """
     temp_filename = f'/tmp/{name}'
 

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1291,7 +1291,7 @@ def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
         with open(priv_path, 'w') as temp_file:
             temp_file.write(out_txt)
 
-        print(f'Wrote temp private key file: {priv_path}'))
+        print(f'Wrote temp private key file: {priv_path}')
         return
 
 def import_pki(

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1334,7 +1334,7 @@ def import_pki(
             )
         elif pki_type == 'openvpn':
             import_openvpn_secret(name, filename)
-        elif pki_type == 'ssh-hostkey': # add handling for importing ssh host keys via copypaste import
+        elif pki_type == 'ssh-hostkey':
             import_ssh_hostkey(name, filename)
         elif pki_type == 'ssh-hostkey-txt-pub':
             save_ssh_hostkey_txt(name, key_txt, "public")

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1211,6 +1211,7 @@ def import_pki(
     key_filename: typing.Optional[str],
     no_prompt: typing.Optional[bool],
     passphrase: typing.Optional[str],
+    key_txt: typing.Optional[str],
 ):
     try:
         if pki_type == 'ca':
@@ -1247,7 +1248,7 @@ def import_pki(
             import_ssh_hostkey(name, filename)
         elif pki_type == 'ssh-hostkey-txt':
             print("got text input for ssh hostkey import")
-            print(name, filename)
+            print(name, key_txt)
             #import_ssh_hostkey(name, txt)
 
 

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1203,15 +1203,17 @@ def generate_pki(
         print('Aborted')
         sys.exit(0)
 
+TEMP_KEY_PATH = '/tmp'
+
 def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
     """Save pasted SSH key text into appropriate temporary filename and format.
 
     For public keys we expect the OpenSSH single-line public key (e.g. "ssh-rsa AAAAB3Nza..."). or just the base64 part.
-    We write it to /tmp/{name}.pub either verbatim or prefixed with the appropriate algorithm identifier.
+    We write it to {TEMP_KEY_PATH}/{name}.pub either verbatim or prefixed with the appropriate algorithm identifier.
     For private keys we accept either a PEM-like block or base64 only. We wrap base64-only keys into a PEM-like block and attach header/footer
     according to the key type, or write it verbatim to the temp file.
     """
-    temp_filename = f'/tmp/{name}'
+    temp_filename = f'{TEMP_KEY_PATH}/{name}'
 
     # Validate supported names
     supported = (
@@ -1226,7 +1228,7 @@ def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
 
     # Public key handling:
     # - If the pasted text already looks like an OpenSSH public key (starts with "ssh-" or "ecdsa-" etc.),
-    #   write it directly to /tmp/{name}.pub
+    #   write it directly to {TEMP_KEY_PATH}/{name}.pub
     # - If the pasted text is just the base64 part, attempt to prefix with the conventional algorithm".
     if type == 'public':
         pub_path = temp_filename + '.pub'
@@ -1252,7 +1254,6 @@ def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
             temp_file.write(pub_line + '\n')
 
         print(f'Wrote temp public key file: {pub_path}')
-        print('Now paste the corresponding private key text to complete the ssh hostkey import.')
         return
 
     # Private key handling:
@@ -1293,6 +1294,20 @@ def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
 
         print(f'Wrote temp private key file: {priv_path}')
         return
+
+def run_import_ssh_hostkey_from_txt(name: str, type: str):
+    #check if both keys exist in TEMP_KEY_PATH and import them
+    key_path_priv = f'{TEMP_KEY_PATH}/{name}'
+    key_path_pub = f'{TEMP_KEY_PATH}/{name}.pub'
+    if os.path.exists(key_path_priv) and os.path.exists(key_path_pub):
+        import_ssh_hostkey(name, key_path_priv)
+        os.remove(key_path_priv)
+        os.remove(key_path_pub)
+    else:
+        if type == 'private':
+            print('Now add the corresponding public key text to complete the ssh hostkey import.')
+        else:
+            print('Now add the corresponding private key text to complete the ssh hostkey import.')
 
 def import_pki(
     name: str,
@@ -1338,18 +1353,10 @@ def import_pki(
             import_ssh_hostkey(name, filename)
         elif pki_type == 'ssh-hostkey-txt-pub':
             save_ssh_hostkey_txt(name, key_txt, "public")
+            run_import_ssh_hostkey_from_txt(name, "public")
         elif pki_type == 'ssh-hostkey-txt-priv':
-            #check if public key exists in /tmp/{name}.pub
-            pub_temp_filename = f'/tmp/{name}.pub'
-            if not os.path.exists(pub_temp_filename):
-                print(f'Corresponding SSH server host public key temp file not found: {pub_temp_filename}. Import Public Key then try again.')
-                return
-            #write key_txt to a temp file and call import_ssh_hostkey with that temp file
             save_ssh_hostkey_txt(name, key_txt, "private")
-            import_ssh_hostkey(name, f'/tmp/{name}')
-            os.remove(f'/tmp/{name}')
-            os.remove(f'/tmp/{name}' + '.pub')
-
+            run_import_ssh_hostkey_from_txt(name, "private")
 
     except KeyboardInterrupt:
         print('Aborted')

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1281,8 +1281,8 @@ def save_ssh_hostkey_txt(name: str, key_txt: str, type: str):
                         header = '-----BEGIN PRIVATE KEY-----'
                         footer = '-----END PRIVATE KEY-----'
 
-                    # wrap lines at 64 chars
-                    wrapped = '\n'.join([b64_body[i:i+64] for i in range(0, len(b64_body), 64)])
+                    # wrap lines at 70 chars
+                    wrapped = '\n'.join([b64_body[i:i+70] for i in range(0, len(b64_body), 70)])
                     out_txt = header + '\n' + wrapped + '\n' + footer + '\n'
                 else:
                     # Fallback: write verbatim


### PR DESCRIPTION
### Op mode ssh host key import via copy/paste
This PR introduces CLI op mode support for importing SSH host keys via copy and paste text. User is now able to import all supported key types via the CLI without needing to save keys to file on the device first by pasting just the base 64 body of the key without any headers/footers in the command.
Since there is no "commit" like there is in config mode and both keys must be present before executing the import via tpm agent. ~the convention taken is that the public key should be imported first, then the private key.~ Either the public or private key can be imported first and the import will complete after both keys have been imported.
The keys are given appropriate furnishings and saved to temporary files in the /tmp/ directory.
After the import, both files are deleted whether successful or not. 

commands created are the _**public-key**_ and _**private-key**_ nodes of each ssh-server-key type:
import pki ssh-server-key type <type> **private-key <key>**
import pki ssh-server-key type <type> **public-key <key>**

some considerations:
After a public/private key is imported, it is immediately saved to a file in /tmp/. if a corresponding public/private key is never imported, the imported key will never be removed from /tmp/.
