### PR TITLE
TPM enable op-mode command that ties in with existing tpm_allowed() py function in python/vyos/tpm.py that should be used for any code that is tpm aware

### DIFF
--- a/op-mode-definitions/show-tpm.xml.in
+++ b/op-mode-definitions/show-tpm.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="tpm">
+        <properties>
+          <help>Show TPM Hardware support and operational status</help>
+        </properties>
+        <command>${vyos_op_scripts_dir}/show_tpm.py</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/tpm.xml.in
+++ b/op-mode-definitions/tpm.xml.in
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="tpm">
+    <properties>
+      <help>Enable/disable TPM2 support for key storage and TPM backed keys</help>
+    </properties>
+    <children>
+      <node name="disable">
+        <properties>
+          <help>Disable TPM2 support for key storage and TPM backed keys</help>
+        </properties>
+        <command>${vyos_libexec_dir}/vyos-opmode-tpm.py --disable</command>
+      </node>
+      <node name="enable">
+        <properties>
+          <help>Enable TPM2 support for key storage and TPM backed keys</help>
+        </properties>
+        <command>${vyos_libexec_dir}/vyos-opmode-tpm.py --enable</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/tpm.py
+++ b/python/vyos/tpm.py
@@ -97,16 +97,73 @@ def write_tpm_key(key, index=0, pcrs=default_pcrs):
 
 # PERLE - added check for tpm support
 
+from vyos.utils.process import cmd
+
+tpm_enabled_path = "/etc/vyos/tpm.enabled"
+tpm_dev_path = "/sys/class/tpm/tpm0"
+
+def tpm_exist():
+    """
+     Args:
+        none
+
+    Returns:
+        True if tpm device exists, False otherwise.
+
+    Note:
+        For now, it returns True/False based on /sys/class/tpm/tpm0 existing or not.
+    """
+    return os.path.exists(tpm_dev_path)
+
+def tpm_enabled():
+    """
+     Args:
+        none
+
+    Returns:
+        True if tpm support enabled by user, False otherwise.
+
+    Note:
+        For now, it returns True/False based on file /etc/vyos/tpm.enabled existing or not.
+    """
+    return os.path.exists(tpm_enabled_path)
+
 def tpm_allowed():
     """
      Args:
         none
 
     Returns:
-        True if tpm allowed (configured or exists), False otherwise.
+        True if tpm allowed (configured AND tpm device exists), False otherwise.
 
     Note:
         For now, it returns True/False based on /sys/class/tpm/tpm0 existing or not.
     """
-    tpm_path = "/sys/class/tpm/tpm0"
-    return os.path.exists(tpm_path)
+    return tpm_enabled() and tpm_exist() 
+
+
+def tpm_enable():
+    """
+     Args:
+        none
+
+    Returns:
+        none
+
+    Note:
+        For now, it touches/creates /etc/vyos/tpm.enabled.
+    """
+    cmd(f'sudo touch {tpm_enabled_path}')
+
+def tpm_disable():
+    """
+     Args:
+        none
+
+    Returns:
+        none
+
+    Note:
+        For now, it removes /etc/vyos/tpm.enabled.
+    """
+    cmd(f'sudo rm -f {tpm_enabled_path}')

--- a/src/helpers/vyos-opmode-tpm.py
+++ b/src/helpers/vyos-opmode-tpm.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import sys
+import subprocess
+import time
+
+from argparse import ArgumentParser
+# from cryptography.fernet import Fernet
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+from vyos.tpm import tpm_exist, tpm_enabled, tpm_allowed, tpm_enable, tpm_disable 
+from vyos.utils.io import ask_input, ask_yes_no
+from vyos.utils.process import cmd, run
+from vyos.defaults import directories
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Must specify action.")
+        sys.exit(1)
+
+    parser = ArgumentParser(description='Operation TPM enable/disable')
+    parser.add_argument('--disable', help='Disable TPM', action="store_true")
+    parser.add_argument('--enable', help='Enable TPM', action="store_true")
+    args = parser.parse_args()
+
+    if args.disable:
+        if not tpm_exist():
+            print('TPM hardware not supported on this product, ignoring command')
+            sys.exit(0)
+        if not tpm_enabled():
+            print('TPM support already disabled, ignoring command')
+            sys.exit(0)
+        tpm_disable()
+        print('TPM support disabled, reboot required.')
+
+    elif args.enable:
+        if not tpm_exist():
+            print('TPM hardware not supported on this product, ignoring command')
+            sys.exit(0)
+        if tpm_enabled():
+            print('TPM support already enabled, ignoring command')
+            sys.exit(0)
+        tpm_enable()
+        print('TPM support enabled, reboot required.')
+
+    print('TPM mode changes... rebooting in 5 seconds....')
+    time.sleep(5)
+    subprocess.run(["python3", "/usr/libexec/vyos/op_mode/powerctrl.py", "--yes", "--reboot"])
+    sys.exit(0)

--- a/src/op_mode/show_tpm.py
+++ b/src/op_mode/show_tpm.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import sys
+import subprocess
+import time
+
+from argparse import ArgumentParser
+
+from vyos.tpm import tpm_exist, tpm_enabled 
+from vyos.utils.process import cmd, run
+
+if __name__ == '__main__':
+
+    if tpm_exist():
+        tpm_hw_string = "Supported"
+    else:
+        tpm_hw_string = "Not supported"
+
+    print(f'TPM hardware:       {tpm_hw_string}')
+
+    if tpm_enabled():
+        tpm_mode_string = "Enabled"
+    else:
+        tpm_mode_string = "Disabled"
+
+    print(f'TPM Operation Mode: {tpm_mode_string}')
+    sys.exit(0)


### PR DESCRIPTION
TPM enable op-mode command that ties in with existing tpm_allowed() py function in python/vyos/tpm.py that should be used for any code that is tpm aware.  There is a corresponding "show tpm" command.  The default tpm operation mode is "disabled".   We can improve the "tpm enable" command as we progress to add a "are you sure Y/N" prompt and additional backend code to remove tpm backed keys and flush the tpm storage when disabling tpm.  When enabling tpm, we would need to clear any previously save keys in the clear.  New op-mode commands added:

tpm enable | disable
show tpm
