### PR TITLE
Add reset button/factory image boot where uboot will check reset button gpio and FAT write file so grub will be to boot factory image or current image

### DIFF
--- a/data/templates/grub/grub_vars.j2
+++ b/data/templates/grub/grub_vars.j2
@@ -2,3 +2,15 @@
 set {{ var_name | e }}="{{ var_value | e }}"
 export {{ var_name | e }}
 {% endfor %}
+
+{% raw %}
+source (hd0,gpt2)/RESET.ENV
+
+if [ "${reset}" == "1" ]; then
+    echo "Factory default iGOS boot ...."
+    set default=${factory}
+else
+    echo "Normal iGOS boot ...."
+    set default=${current}
+fi
+{% endraw %}

--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -160,6 +160,10 @@ def version_list(root_dir: str = '') -> list[str]:
     versions_files = Path(f'{root_dir}/{GRUB_DIR_VYOS_VERS}').glob('*.cfg')
     versions_order: dict[str, int] = {}
     for file in versions_files:
+        # PSL - Skip the default firmware file
+        if file.name == "default-firmware.cfg":
+            continue
+
         p = Path(root_dir).joinpath('boot').joinpath(file.stem)
         command = f'stat -c %W {p.as_posix()}'
         rc, out = rc_cmd(command)
@@ -354,6 +358,41 @@ def set_default(version_name: str, root_dir: str = '') -> None:
     vars_current['default'] = gen_version_uuid(version_name)
     vars_write(vars_file, vars_current)
 
+# PSL - START - New routines to set factory firmware uuid and current uuid
+
+def set_current_default(version_name: str, root_dir: str = '') -> None:
+    """Set version uuid as current boot entry
+
+    Args:
+        version_name (str): version name (current)
+        root_dir (str, optional): an optional path to the root directory.
+        Defaults to empty.
+    """
+    if not root_dir:
+        root_dir = disk.find_persistence()
+
+    vars_file = f'{root_dir}/{CFG_VYOS_VARS}'
+    vars_current = vars_read(vars_file)
+    vars_current['current'] = gen_version_uuid(version_name)
+    vars_write(vars_file, vars_current)
+
+def set_factory_default(version_name: str, root_dir: str = '') -> None:
+    """Set factory version uuid for default-firmware boot entry
+
+    Args:
+        version_name (str): version name (of default-firmware)
+        root_dir (str, optional): an optional path to the root directory.
+        Defaults to empty.
+    """
+    if not root_dir:
+        root_dir = disk.find_persistence()
+
+    vars_file = f'{root_dir}/{CFG_VYOS_VARS}'
+    vars_current = vars_read(vars_file)
+    vars_current['factory'] = gen_version_uuid(version_name)
+    vars_write(vars_file, vars_current)
+
+# PSL - END - New routines to set factory firmware uuid and current uuid
 
 def common_write(root_dir: str = '', grub_common: dict[str, str] = {}) -> None:
     """Write common GRUB configuration file (overwrite everything)

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -143,7 +143,7 @@ DIR_ROOTFS_SRC: str = f'{DIR_INSTALLATION}/root_src'
 DIR_ROOTFS_DST: str = f'{DIR_INSTALLATION}/root_dst'
 DIR_ISO_MOUNT: str = f'{DIR_INSTALLATION}/iso_src'
 DIR_DST_ROOT: str = f'{DIR_INSTALLATION}/disk_dst'
-DIR_KERNEL_SRC: str = '/boot/'
+DIR_KERNEL_SRC: str = '/boot'
 FILE_ROOTFS_SRC: str = '/usr/lib/live/mount/medium/live/filesystem.squashfs'
 ISO_DOWNLOAD_PATH: str = ''
 
@@ -1000,17 +1000,33 @@ def install_image() -> None:
         # copy system image and kernel files
         print('Copying system image files')
 
-        # PSL - copy all system files and symlinks, also rename the filesyste.squashfs
+        # PSL - copy all system files and symlinks, also rename the filesystem.squashfs
+        # Note: DIR_KERNEL_SRC is /boot that within the RUNNING filesystem.squashfs and
+        #       does NOT contain the filesystem.squashfs file itself but has the dtb and grub
         copytree(f"{DIR_KERNEL_SRC}/",
                  f"{DIR_DST_ROOT}/boot/{image_name}/",
                  dirs_exist_ok=True,
                  symlinks=True)
+
+        # PSL - from previous copytree() the dtb and grub directories were copied to the
+        #       installation directory, so we can remove them so the installation looks
+        #       EXACTLY like an iso installation using "add system image <isoname>"
+        tmppath = Path(f'{DIR_DST_ROOT}/boot/{image_name}/dtb')
+        if tmppath.exists():
+            print(f"Pruning unused {image_name}/dtb directory")
+            rmtree(tmppath, ignore_errors=True)
+
+        tmppath = Path(f'{DIR_DST_ROOT}/boot/{image_name}/grub')
+        if tmppath.exists():
+            print(f"Pruning unused {image_name}/grub directory")
+            rmtree(tmppath, ignore_errors=True)
 
         copy(FILE_ROOTFS_SRC,
              f'{DIR_DST_ROOT}/boot/{image_name}/{image_name}.squashfs')
 
         # PSL - START copy over all dtb files for arm64 processors
         if Path(f"{DIR_KERNEL_SRC}/dtb/ti").exists():
+            print('Copying DTB files')
             copytree(f"{DIR_KERNEL_SRC}/dtb/ti",
                      f"{DIR_DST_ROOT}/boot/dtb/ti",
                      dirs_exist_ok=True)
@@ -1030,8 +1046,41 @@ def install_image() -> None:
         # add information about version
         grub.create_structure()
         grub.version_add(image_name, DIR_DST_ROOT)
-        grub.set_default(image_name, DIR_DST_ROOT)
+        # PSL - grub.set_default(image_name, DIR_DST_ROOT)
+        grub.set_current_default(image_name, DIR_DST_ROOT)
         grub.set_console_type(console_dict[console_type], DIR_DST_ROOT)
+
+        # PSL - START check if default-firmware exists, removes it,  and copy over all system files
+        default_image_name: str = 'default-firmware'
+        path = Path(f'{DIR_DST_ROOT}/boot/{default_image_name}')
+
+        print(f"Default firmware path is: {path}, default image name is: {default_image_name}")
+        if path.exists():
+            print(f"Removing existing default-firmware rootfs at: {path}")
+            rmtree(path)
+
+        print("Creating factory default-firmware installation")
+        copytree(f"{DIR_KERNEL_SRC}/",
+            f"{DIR_DST_ROOT}/boot/{default_image_name}/",
+            dirs_exist_ok=True,
+            symlinks=True)
+
+        tmppath = Path(f'{DIR_DST_ROOT}/boot/{default_image_name}/dtb')
+        if tmppath.exists():
+            print(f"Pruning unused {default_image_name}/dtb directory")
+            rmtree(tmppath, ignore_errors=True)
+
+        tmppath = Path(f'{DIR_DST_ROOT}/boot/{default_image_name}/grub')
+        if tmppath.exists():
+            print(f"Pruning unused {default_image_name}/grub directory")
+            rmtree(tmppath, ignore_errors=True)
+
+        copy(FILE_ROOTFS_SRC,
+            f'{DIR_DST_ROOT}/boot/{default_image_name}/default-firmware.squashfs')
+
+        grub.version_add(default_image_name, DIR_DST_ROOT)
+        grub.set_factory_default(default_image_name, DIR_DST_ROOT)
+        # PSL - END check if default-firmware exists and copy over all system files
 
         if is_raid_install(install_target):
             # add RAID specific modules
@@ -1284,9 +1333,10 @@ def add_image(image_path: str, vrf: str = None, username: str = '',
              f'{root_dir}/boot/{image_name}/{image_name}.squashfs')
 
         # PSL - START copy over all dtb files for arm64 processors
-        if Path(f"{DIR_KERNEL_SRC}/dtb/ti").exists():
-            copytree(f"{DIR_KERNEL_SRC}/dtb/ti",
-                     f"{DIR_DST_ROOT}/boot/dtb/ti",
+        if Path(f"{DIR_ISO_MOUNT}/boot/dtb/ti").exists():
+            print('Copying DTB files')
+            copytree(f"{DIR_ISO_MOUNT}/boot/dtb/ti",
+                     f"{root_dir}/boot/dtb/ti",
                      dirs_exist_ok=True)
 
         # unmount an ISO and cleanup
@@ -1295,7 +1345,8 @@ def add_image(image_path: str, vrf: str = None, username: str = '',
         # add information about version
         grub.version_add(image_name, root_dir)
         if set_as_default:
-            grub.set_default(image_name, root_dir)
+            # PSL - grub.set_default(image_name, root_dir)
+            grub.set_current_default(image_name, root_dir)
 
         if Path(f'{target_config_dir}/config.boot').exists():
             cmdline_options = get_cli_kernel_options(


### PR DESCRIPTION
Mods to install/support a hidden "default-firmware" image, installed along with a base image when running the "install image".    Added grub logic to check for reset button state in mmc0:2/RESET.ENV (reset=1 or reset=0) and boots either the default-firmware or current image respectively. All CLI commands ({set | delete | show} system image) will exclude the default-firmware as an image option. 

Please note: UBOOT was used to manually write "reset=0" or "reset=1" using mw.b write and fatwrite commands below. The UBOOT work that still needs to be done involves adding the following syntax to the boot sequence/enviroment, where xxx is the reset button's gpio number:

gpio input xxx
if test $? -eq 0; then
    setenv resetval 0x31
else
    setenv resetval 0x30
fi

mw.b ${loadaddr}     0x72 1
mw.b 0x82000001   0x65 1
mw.b 0x82000002   0x73 1
mw.b 0x82000003   0x65 1
mw.b 0x82000004   0x74 1
mw.b 0x82000005   0x3d 1
mw.b 0x82000006   ${resetval} 1

fatwrite mmc 0:2 ${loadaddr} /RESET.ENV 7
