### PR TITLE
Fixes for suppressing early DHCP/RARP/dropbear networking and when selecting the default image to boot

### DIFF
--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -46,7 +46,8 @@ TMPL_GRUB_OPTS: str = 'grub/grub_options.j2'
 TMPL_GRUB_COMMON: str = 'grub/grub_common.j2'
 
 # default boot options
-BOOT_OPTS_STEM: str = 'boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/'
+# PERLE - initramfs will run ip-config and dropbear unless we disable early ip and networking in the kernel
+BOOT_OPTS_STEM: str = 'boot=live rootdelay=5 ip=none nonetworking noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/'
 
 # prepare regexes
 REGEX_GRUB_VARS: str = r'^set (?P<variable_name>\w+)=[\'"]?(?P<variable_value>.*)(?<![\'"])[\'"]?$'

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -141,7 +141,8 @@ def set_image(image_name: Optional[str] = None,
 
     # set default boot image
     try:
-        grub.set_default(image_name, persistence_storage)
+        # PSL - grub.set_default(image_name, persistence_storage)
+        grub.set_current_default(image_name, persistence_storage)
         print(f'The image "{image_name}" is now default boot image')
     except Exception as err:
         exit(f'Unable to set default image "{image_name}": {err}')


### PR DESCRIPTION
Two fixes addressed:
1) ip=none and nonetworking options added to kernel command line when using add system image  <iso-name-path>  to suppress early (initrd) dhcp/rarp/dropbear.  Otherwise, the unit would acquire an IP even though your vyos config is different and you would need to manually remove the acquired IP 
2) set system image default-boot <image-name> would mess up the grub config that handles booting factory firmware or any other user installed firmware
