### PR TITLE
Add serial dependency to debian control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -351,6 +351,9 @@ Depends:
   vpp-plugin-core,
   vpp-plugin-dpdk,
 # End "vpp"
+# For "serial"
+  monitor,
+# End "serial"
 ## End Configuration mode
 ## Operational mode
 # Used for hypervisor model in "run show version"

--- a/debian/control
+++ b/debian/control
@@ -352,7 +352,7 @@ Depends:
   vpp-plugin-dpdk,
 # End "vpp"
 # For "serial"
-  monitor,
+  psl-iolan-monitor,
 # End "serial"
 ## End Configuration mode
 ## Operational mode


### PR DESCRIPTION
The added monitor package acts as the central control package, the library and service deb packages are defined as dependencies in its debian/control file.