### PR TITLE
Partially undo the T8120 change that imposes that all arm64 processors use ttyAMAx high perf uart instead of ttySx

### DIFF
--- a/data/templates/grub/grub_options.j2
+++ b/data/templates/grub/grub_options.j2
@@ -29,7 +29,9 @@ submenu "Boot options" {
         }
         menuentry "ttyS (serial)" {
             if [ "${grub_cpu}" == "arm64" ]; then
-                set serial_console="ttyAMA"
+#               PSL - for TI ARM64 ttySx is the console type
+#               set serial_console="ttyAMA"
+                set serial_console="ttyS"
             else
                 set serial_console="ttyS"
             fi


### PR DESCRIPTION
The VyOS developers changed the console from ttyS0 to ttyAMA0 likely due to support for running under an ARM64 VM.  Some ARM64 processors may also use the ttyAMA0 for built in high performance uart, but for our TI based ARM64 processors, we need ttyS0 instead.  This is a minimal revert back to ttyS0 by setting the default console, leaving in most of the python/grub rendering logic as part of T8120 code changes 

