### PR TITLE
Add probing and setting the root=UUID=xxxxxxxx in grub and pass to kernel cmdline

### DIFF
--- a/data/templates/grub/grub_vyos_version.j2
+++ b/data/templates/grub/grub_vyos_version.j2
@@ -10,7 +10,9 @@
 {%     set boot_opts_rendered = boot_opts_default %}
 {% endif %}
 menuentry "{{ version_name }}" --id {{ version_uuid }} {
+    probe -u (hd0,gpt3) --set=disk_uuid
     set boot_opts="{{ boot_opts_rendered }}"
+    set boot_opts="${boot_opts} root=UUID=${disk_uuid}"
     if [ "${console_type}" == "ttyS" -o "${console_type}" == "ttyAMA" ]; then
         set console_opts="console=${console_type}${console_num},${console_speed}"
     else


### PR DESCRIPTION
When booting from eMMC with squashfs/overlayfs system image, we get associated warning/errors in the boot log.  Although we do not think it is causing any issues, the fix is to set root=UUID=xxxxxx in the grub boot options that is passed to the kernel command line and can be accessed in /proc/cmdline.   Each eMMC EXT4 partition 3 has a unique UUID.

Apr 17 22:08:06 systemd[1]: Reloading.
Apr 17 22:08:07 systemd-gpt-auto-generator[6750]: EFI loader partition unknown, exiting.
Apr 17 22:08:07 systemd-gpt-auto-generator[6750]: (The boot loader did not set EFI variable LoaderDevicePartUUID.)

