### PR TITLE
Add sync conmmand after add and install image installation

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -1491,7 +1491,7 @@ if __name__ == '__main__':
             add_image(args.image_path, args.vrf,
                       args.username, args.password,
                       args.no_prompt, args.force)
-
+        sync()
         exit()
 
     except KeyboardInterrupt:


### PR DESCRIPTION
Added sync to the script so user can immediately power off/on without a manual 'sync' after adding and installing new image via 'add system image'.  Previously without the fix, after immediately resetting, would only partially write or get a grub error for missing image. 