### PR TITLE
changes in grub to read/source the env vars from product.env writtenby uboot, to add to kernel cmdline /proc/cmdline for dtb/pinmux customization

### DIFF
--- a/data/templates/grub/grub_vars.j2
+++ b/data/templates/grub/grub_vars.j2
@@ -5,6 +5,7 @@ export {{ var_name | e }}
 
 {% raw %}
 source (hd0,gpt2)/RESET.ENV
+source (hd0,gpt2)/product.env
 
 if [ "${reset}" == "1" ]; then
     echo "Factory default iGOS boot ...."

--- a/data/templates/grub/grub_vyos_version.j2
+++ b/data/templates/grub/grub_vyos_version.j2
@@ -12,7 +12,7 @@
 menuentry "{{ version_name }}" --id {{ version_uuid }} {
     probe -u (hd0,gpt3) --set=disk_uuid
     set boot_opts="{{ boot_opts_rendered }}"
-    set boot_opts="${boot_opts} root=UUID=${disk_uuid}"
+    set boot_opts="${boot_opts} root=UUID=${disk_uuid} ${prod_id} ${model}"
     if [ "${console_type}" == "ttyS" -o "${console_type}" == "ttyAMA" ]; then
         set console_opts="console=${console_type}${console_num},${console_speed}"
     else


### PR DESCRIPTION
Changes so when uboot reads EEPROM and pass the prod_id, model, mac, etc to Grub and Linux via a /product.env text file in the FAT partition mmcblk0p2, grub can now read/source that file and pass the prod_id and model to the kernel command line by including as part of boot_opts.  The uEnv.txt file will need to be modified to use the format for dtb to load (when the various model specific dtbs are ready) k3-am642-${prod_id}-${model}.dtb