### PR TITLE
SMTP email client support using app password or oauth2 authentication.  Configuration and operational mode commands included

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -357,7 +357,7 @@ Depends:
 # For email client 
   msmtp,
   msmtp-mta,
-# End  email cleint
+# End  email client
 ## End Configuration mode
 ## Operational mode
 # Used for hypervisor model in "run show version"

--- a/debian/control
+++ b/debian/control
@@ -354,6 +354,10 @@ Depends:
 # For web interface
   flask-react-web,
 # End web interface
+# For email client 
+  msmtp,
+  msmtp-mta,
+# End  email cleint
 ## End Configuration mode
 ## Operational mode
 # Used for hypervisor model in "run show version"

--- a/interface-definitions/system_email.xml.in
+++ b/interface-definitions/system_email.xml.in
@@ -1,0 +1,178 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+
+  <node name="system">
+    <properties>
+      <help>System configuration</help>
+    </properties>
+
+    <children>
+
+      <node name="email"
+            owner="${vyos_conf_scripts_dir}/system_email.py">
+        <properties>
+          <help>System SMTP email client settings</help>
+          <priority>1000</priority>
+        </properties>
+
+        <children>
+
+          <leafNode name="active-profile">
+            <properties>
+              <help>Active global SMTP server profile</help>
+            </properties>
+          </leafNode>
+
+          <tagNode name="profile">
+            <properties>
+              <help>SMTP profile</help>
+            </properties>
+
+            <children>
+
+              <leafNode name="smtp-host">
+                <properties>
+                  <help>SMTP server address</help>
+                </properties>
+              </leafNode>
+
+              <leafNode name="port">
+                <properties>
+                  <help>SMTP port</help>
+                </properties>
+                <defaultValue>587</defaultValue>
+              </leafNode>
+
+              <leafNode name="authentication">
+                <properties>
+                  <help>Authentication method</help>
+                  <completionHelp>
+                    <list>password oauth2</list>
+                  </completionHelp>
+                </properties>
+                <defaultValue>password</defaultValue>
+              </leafNode>
+
+              <leafNode name="username">
+                <properties>
+                  <help>SMTP username or email address</help>
+                </properties>
+              </leafNode>
+
+              <leafNode name="password">
+                <properties>
+                  <help>SMTP password</help>
+                  <secret/>
+                </properties>
+              </leafNode>
+
+              <node name="oauth2">
+                <properties>
+                  <help>OAuth2 authentication settings</help>
+                </properties>
+
+                <children>
+
+                  <leafNode name="token-url">
+                    <properties>
+                      <help>OAuth2 token endpoint URL</help>
+                    </properties>
+                  </leafNode>
+
+                  <leafNode name="client-id">
+                    <properties>
+                      <help>OAuth2 client ID</help>
+                    </properties>
+                  </leafNode>
+
+                  <leafNode name="client-secret">
+                    <properties>
+                      <help>OAuth2 client secret</help>
+                      <secret/>
+                    </properties>
+                  </leafNode>
+
+                  <leafNode name="refresh-token">
+                    <properties>
+                      <help>OAuth2 refresh token</help>
+                      <secret/>
+                    </properties>
+                  </leafNode>
+
+                  <leafNode name="scope">
+                    <properties>
+                      <help>Optional OAuth2 scope</help>
+                    </properties>
+                  </leafNode>
+
+                </children>
+              </node>
+
+              <leafNode name="security">
+                <properties>
+                  <help>Security mode</help>
+                  <completionHelp>
+                    <list>none tls starttls</list>
+                  </completionHelp>
+                </properties>
+                <defaultValue>starttls</defaultValue>
+              </leafNode>
+
+              <leafNode name="no-validate-cert">
+                <properties>
+                  <help>Disable TLS certificate validation</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+
+              <leafNode name="ca-file">
+                <properties>
+                  <help>Custom CA file located in /etc/ssl/certs</help>
+                </properties>
+              </leafNode>
+
+              <leafNode name="from-email">
+                <properties>
+                  <help>Sender email address</help>
+                </properties>
+              </leafNode>
+
+            </children>
+          </tagNode>
+
+          <tagNode name="recipient">
+            <properties>
+              <help>Email recipients</help>
+            </properties>
+
+            <children>
+
+              <leafNode name="enable">
+                <properties>
+                  <help>Enable recipient</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+
+              <leafNode name="email">
+                <properties>
+                  <help>Email address</help>
+                </properties>
+              </leafNode>
+
+              <leafNode name="subject">
+                <properties>
+                  <help>Email subject</help>
+                </properties>
+              </leafNode>
+
+            </children>
+          </tagNode>
+
+        </children>
+      </node>
+
+    </children>
+  </node>
+
+</interfaceDefinition>

--- a/op-mode-definitions/generate_test_email.xml.in
+++ b/op-mode-definitions/generate_test_email.xml.in
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="generate">
+    <children>
+      <node name="test-email">
+        <properties>
+          <help>Send a system test notification email to all enabled recipients</help>
+        </properties>
+        <!-- Pathway A: Executed when user hits enter right at 'generate test-email' -->
+        <command>${vyos_op_scripts_dir}/generate_test_email.py</command>
+        <children>
+          <tagNode name="message">
+            <properties>
+              <help>Optional custom email message text sentence</help>
+            </properties>
+            <!-- Pathway B: Executed when user appends custom single/double quoted text, { } are needed -->
+            <command>${vyos_op_scripts_dir}/generate_test_email.py "${4}"</command>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>
+

--- a/src/conf_mode/system_email.py
+++ b/src/conf_mode/system_email.py
@@ -209,10 +209,12 @@ def verify(cfg):
                     f"Profile '{name}' requires client-id"
                 )
 
-            if not oauth['client_secret']:
-                raise ConfigError(
-                    f"Profile '{name}' requires client-secret"
-                )
+            # client-secret is optional for some OAuth2 providers (public clients)
+            # and the msmtp helper supports an empty CLIENT_SECRET.
+            # if not oauth['client_secret']:
+            #     raise ConfigError(
+            #         f"Profile '{name}' requires client-secret"
+            #     )
 
             if not oauth['refresh_token']:
                 raise ConfigError(
@@ -346,8 +348,8 @@ def generate(cfg):
         content += [
             'auth on',
             'auth plain',
-            f'user {p["username"]}',
-            f'password {p["password"]}'
+            f'user "{p["username"]}"',
+            f'password "{p["password"]}"'
         ]
 
     elif p['authentication'] == 'oauth2':
@@ -360,7 +362,7 @@ def generate(cfg):
         content += [
             'auth on',
             'auth oauthbearer',
-            f'user {p["username"]}',
+            f'user "{p["username"]}"',
             f'passwordeval {OAUTH_HELPER} {name}'
         ]
 

--- a/src/conf_mode/system_email.py
+++ b/src/conf_mode/system_email.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from vyos.config import Config
+from vyos import ConfigError
+
+CONFIG_DIR = '/run/msmtp'
+CONFIG_FILE = f'{CONFIG_DIR}/msmtprc'
+GLOBAL_LINK = '/etc/msmtprc'
+
+OAUTH_DIR = f'{CONFIG_DIR}/oauth'
+
+OAUTH_HELPER = '/usr/libexec/vyos/msmtp-oauth-helper.sh'
+
+SYSTEM_CA_DIR = '/etc/ssl/certs'
+DEFAULT_CA_BUNDLE = f'{SYSTEM_CA_DIR}/ca-certificates.crt'
+
+
+def get_config(config=None):
+    if config is None:
+        config = Config()
+
+    base = ['system', 'email']
+
+    if not config.exists(base):
+        return None
+
+    data = {
+        'active_profile': config.return_value(
+            base + ['active-profile']
+        ),
+        'profiles': {},
+        'recipients': {}
+    }
+
+    if config.exists(base + ['profile']):
+
+        for profile in config.list_nodes(base + ['profile']):
+
+            path = base + ['profile', profile]
+
+            ca_val = config.return_value(
+                path + ['ca-file']
+            )
+
+            data['profiles'][profile] = {
+                'smtp_host':
+                    config.return_value(
+                        path + ['smtp-host']
+                    ),
+
+                'port':
+                    config.return_value(
+                        path + ['port']
+                    ) or '587',
+
+                'authentication':
+                    config.return_value(
+                        path + ['authentication']
+                    ) or 'password',
+
+                'username':
+                    config.return_value(
+                        path + ['username']
+                    ),
+
+                'password':
+                    config.return_value(
+                        path + ['password']
+                    ),
+
+                'security':
+                    config.return_value(
+                        path + ['security']
+                    ) or 'starttls',
+
+                'validate_cert':
+                    not config.exists(
+                        path + ['no-validate-cert']
+                    ),
+
+                'ca_file':
+                    ca_val.strip()
+                    if isinstance(ca_val, str)
+                    and ca_val.strip()
+                    else None,
+
+                'from_email':
+                    config.return_value(
+                        path + ['from-email']
+                    ),
+
+                'oauth2': {
+                    'token_url':
+                        config.return_value(
+                            path + ['oauth2', 'token-url']
+                        ),
+
+                    'client_id':
+                        config.return_value(
+                            path + ['oauth2', 'client-id']
+                        ),
+
+                    'client_secret':
+                        config.return_value(
+                            path + ['oauth2', 'client-secret']
+                        ),
+
+                    'refresh_token':
+                        config.return_value(
+                            path + ['oauth2', 'refresh-token']
+                        ),
+
+                    'scope':
+                        config.return_value(
+                            path + ['oauth2', 'scope']
+                        ),
+                }
+            }
+
+    if config.exists(base + ['recipient']):
+
+        for r in config.list_nodes(
+                base + ['recipient']):
+
+            rpath = base + ['recipient', r]
+
+            data['recipients'][r] = {
+                'email':
+                    config.return_value(
+                        rpath + ['email']
+                    ),
+
+                'subject':
+                    config.return_value(
+                        rpath + ['subject']
+                    ),
+
+                'enabled':
+                    config.exists(
+                        rpath + ['enable']
+                    )
+            }
+
+    return data
+
+
+def verify(cfg):
+
+    if not cfg:
+        return
+
+    active = cfg['active_profile']
+
+    if active and active not in cfg['profiles']:
+        raise ConfigError(
+            f"Profile '{active}' not defined"
+        )
+
+    for name, p in cfg['profiles'].items():
+
+        if not p['smtp_host']:
+            raise ConfigError(
+                f"Profile '{name}' requires smtp-host"
+            )
+
+        if p['ca_file']:
+
+            full = os.path.join(
+                SYSTEM_CA_DIR,
+                p['ca_file']
+            )
+
+            if not os.path.exists(full):
+                raise ConfigError(
+                    f"CA file '{full}' not found"
+                )
+
+        if p['authentication'] == 'password':
+
+            if not p['username']:
+                raise ConfigError(
+                    f"Profile '{name}' requires username"
+                )
+
+            if not p['password']:
+                raise ConfigError(
+                    f"Profile '{name}' requires password"
+                )
+
+        elif p['authentication'] == 'oauth2':
+
+            oauth = p['oauth2']
+
+            if not p['username']:
+                raise ConfigError(
+                    f"Profile '{name}' requires username"
+                )
+
+            if not oauth['token_url']:
+                raise ConfigError(
+                    f"Profile '{name}' requires token-url"
+                )
+
+            if not oauth['client_id']:
+                raise ConfigError(
+                    f"Profile '{name}' requires client-id"
+                )
+
+            if not oauth['client_secret']:
+                raise ConfigError(
+                    f"Profile '{name}' requires client-secret"
+                )
+
+            if not oauth['refresh_token']:
+                raise ConfigError(
+                    f"Profile '{name}' requires refresh-token"
+                )
+
+
+def cleanup_oauth():
+
+    if not os.path.isdir(OAUTH_DIR):
+        return
+
+    for filename in os.listdir(OAUTH_DIR):
+
+        if (
+            filename.endswith('.conf')
+            or filename.endswith('.token')
+        ):
+
+            try:
+                os.unlink(
+                    os.path.join(
+                        OAUTH_DIR,
+                        filename
+                    )
+                )
+
+            except OSError:
+                pass
+
+
+def generate_oauth_profile(name, oauth):
+
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    os.makedirs(OAUTH_DIR, exist_ok=True)
+
+    conf = f'{OAUTH_DIR}/{name}.conf'
+
+    with open(conf, 'w') as f:
+        f.write(
+            f'TOKEN_URL="{oauth["token_url"] or ""}"\n'
+            f'CLIENT_ID="{oauth["client_id"] or ""}"\n'
+            f'CLIENT_SECRET="{oauth["client_secret"] or ""}"\n'
+            f'REFRESH_TOKEN="{oauth["refresh_token"] or ""}"\n'
+            f'SCOPE="{oauth["scope"] or ""}"\n'
+        )
+
+    os.chmod(conf, 0o600)
+
+
+def generate(cfg):
+
+    if not cfg:
+        return
+
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    os.makedirs(OAUTH_DIR, exist_ok=True)
+
+    cleanup_oauth()
+
+    name = cfg.get('active_profile')
+
+    if not name or name not in cfg['profiles']:
+
+        if os.path.exists(CONFIG_FILE):
+            os.remove(CONFIG_FILE)
+
+        return
+
+    p = cfg['profiles'][name]
+
+    content = [
+        '# Generated by VyOS system_email.py',
+        'defaults',
+        'syslog LOG_MAIL',
+        '',
+        f'account {name}',
+        f'host {p["smtp_host"]}',
+        f'port {p["port"]}',
+    ]
+
+    if p['from_email']:
+        content.append(
+            f'from {p["from_email"]}'
+        )
+
+    if p['security'] == 'tls':
+
+        content += [
+            'tls on',
+            'tls_starttls off'
+        ]
+
+    elif p['security'] == 'starttls':
+
+        content += [
+            'tls on',
+            'tls_starttls on'
+        ]
+
+    else:
+
+        content.append('tls off')
+
+    if p['security'] in ['tls', 'starttls']:
+
+        if p['validate_cert']:
+
+            if p['ca_file']:
+
+                content.append(
+                    f'tls_trust_file '
+                    f'{SYSTEM_CA_DIR}/{p["ca_file"]}'
+                )
+
+            else:
+
+                content.append(
+                    f'tls_trust_file '
+                    f'{DEFAULT_CA_BUNDLE}'
+                )
+
+        else:
+
+            content.append(
+                'tls_certcheck off'
+            )
+
+    if p['authentication'] == 'password':
+
+        content += [
+            'auth on',
+            'auth plain',
+            f'user {p["username"]}',
+            f'password {p["password"]}'
+        ]
+
+    elif p['authentication'] == 'oauth2':
+
+        generate_oauth_profile(
+            name,
+            p['oauth2']
+        )
+
+        content += [
+            'auth on',
+            'auth oauthbearer',
+            f'user {p["username"]}',
+            f'passwordeval {OAUTH_HELPER} {name}'
+        ]
+
+    else:
+
+        content.append('auth off')
+
+    content += [
+        '',
+        f'account default : {name}'
+    ]
+
+    tmp = CONFIG_FILE + '.tmp'
+
+    with open(tmp, 'w') as f:
+        f.write('\n'.join(content))
+
+    os.chmod(tmp, 0o600)
+
+    os.replace(tmp, CONFIG_FILE)
+
+
+def apply(cfg):
+
+    if not cfg:
+        return
+
+    name = cfg.get('active_profile')
+
+    if name and name in cfg['profiles']:
+
+        if os.path.islink(GLOBAL_LINK):
+            os.remove(GLOBAL_LINK)
+
+        elif os.path.exists(GLOBAL_LINK):
+            os.remove(GLOBAL_LINK)
+
+        os.symlink(
+            CONFIG_FILE,
+            GLOBAL_LINK
+        )
+
+    else:
+
+        if os.path.islink(GLOBAL_LINK):
+            os.remove(GLOBAL_LINK)
+
+
+if __name__ == '__main__':
+
+    try:
+        cfg = get_config()
+        verify(cfg)
+        generate(cfg)
+        apply(cfg)
+
+    except ConfigError as e:
+
+        print(
+            f'Configuration Error: {e}',
+            file=sys.stderr
+        )
+
+        sys.exit(1)

--- a/src/helpers/msmtp-oauth-helper.sh
+++ b/src/helpers/msmtp-oauth-helper.sh
@@ -31,6 +31,10 @@ if [ -n "$CLIENT_SECRET" ]; then
     ARGS+=(-d "client_secret=$CLIENT_SECRET")
 fi
 
+if [ -n "$SCOPE" ]; then
+    ARGS+=(-d "scope=$SCOPE")
+fi
+
 RESPONSE=$(curl "${ARGS[@]}" "$TOKEN_URL")
 
 ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')

--- a/src/helpers/msmtp-oauth-helper.sh
+++ b/src/helpers/msmtp-oauth-helper.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+PROFILE="$1"
+
+CFG="/run/msmtp/oauth/${PROFILE}.conf"
+CACHE="/run/msmtp/oauth/${PROFILE}.token"
+
+source "$CFG"
+
+NOW=$(date +%s)
+
+if [ -f "$CACHE" ]; then
+    source "$CACHE"
+
+    if [ "${EXPIRES_AT:-0}" -gt $((NOW+300)) ]; then
+        echo "$ACCESS_TOKEN"
+        exit 0
+    fi
+fi
+
+ARGS=(
+    -s
+    -d "grant_type=refresh_token"
+    -d "client_id=$CLIENT_ID"
+    -d "refresh_token=$REFRESH_TOKEN"
+)
+
+if [ -n "$CLIENT_SECRET" ]; then
+    ARGS+=(-d "client_secret=$CLIENT_SECRET")
+fi
+
+RESPONSE=$(curl "${ARGS[@]}" "$TOKEN_URL")
+
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+
+if [ -n "$ERROR" ]; then
+    echo "$RESPONSE" >&2
+    exit 1
+fi
+
+ACCESS_TOKEN=$(echo "$RESPONSE" | jq -r '.access_token')
+EXPIRES_IN=$(echo "$RESPONSE" | jq -r '.expires_in')
+
+EXPIRES_AT=$((NOW+EXPIRES_IN))
+
+cat > "$CACHE" <<EOF
+ACCESS_TOKEN='$ACCESS_TOKEN'
+EXPIRES_AT='$EXPIRES_AT'
+EOF
+
+chmod 600 "$CACHE"
+
+echo "$ACCESS_TOKEN"

--- a/src/op_mode/generate_test_email.py
+++ b/src/op_mode/generate_test_email.py
@@ -10,7 +10,11 @@ import subprocess
 import sys
 from datetime import datetime
 
-sys.path.append('/usr/libexec/vyos/conf_mode')
+from vyos.defaults import directories
+sys.path.append(directories['conf_mode'])
+
+# sys.path.append('/usr/libexec/vyos/conf_mode')
+
 try:
     import system_email
 except ImportError:
@@ -46,7 +50,8 @@ def send_test_email(message: str) -> None:
     print(f"Processing delivery to {len(enabled_recipients)} enabled recipient(s)...")
 
     success_count = 0
-    date_str = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
+    date_str = datetime.now().astimezone().strftime("%a, %d %b %Y %H:%M:%S %z")
+    # date_str = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
 
     for alias, data in enabled_recipients.items():
         target_email = data.get('email') or alias

--- a/src/op_mode/generate_test_email.py
+++ b/src/op_mode/generate_test_email.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# Copyright Perle maintainers and contributors <psleng@perle.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+
+import subprocess
+import sys
+from datetime import datetime
+
+sys.path.append('/usr/libexec/vyos/conf_mode')
+try:
+    import system_email
+except ImportError:
+    print("Error: System email configuration subsystem is not installed.")
+    sys.exit(1)
+
+
+def send_test_email(message: str) -> None:
+    """Locate active profiles and send out a standard test email cleanly using a string input."""
+    cfg = system_email.get_config()
+    if not cfg:
+        print("Error: No system email client settings found.")
+        sys.exit(1)
+
+    active_profile = cfg.get('active_profile')
+    if not active_profile:
+        print("Aborted: There is no active email profile configured.")
+        print("Run: 'set system email active-profile <name>' inside config mode first.")
+        sys.exit(1)
+
+    if active_profile not in cfg.get('profiles', {}):
+        print(f"Error: Active profile '{active_profile}' has no server specifications.")
+        sys.exit(1)
+
+    recipients = cfg.get('recipients', {})
+    enabled_recipients = {k: v for k, v in recipients.items() if v.get('enabled') is True}
+
+    if not enabled_recipients:
+        print("Aborted: There are no enabled recipients configured to receive alerts.")
+        sys.exit(1)
+
+    print(f"Using active SMTP profile: [{active_profile}]")
+    print(f"Processing delivery to {len(enabled_recipients)} enabled recipient(s)...")
+
+    success_count = 0
+    date_str = datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
+
+    for alias, data in enabled_recipients.items():
+        target_email = data.get('email') or alias
+        
+        if not target_email or "@" not in str(target_email):
+            print(f" -> Skipping recipient [{alias}]: Invalid or missing destination email address.")
+            continue
+
+        subject_prefix = data.get('subject') or "VyOS Notification"
+        subject_line = f"{subject_prefix}: Operational Test Message"
+
+        # Dynamically map custom message input string vs internal system text default
+        if message:
+            message_content = f"Custom Message:\n{message}"
+        else:
+            message_content = (
+                "This is a live diagnostic verification email generated natively "
+                "by the VyOS operational command system."
+            )
+
+        email_body = (
+            f"To: {target_email}\n"
+            f"Subject: {subject_line}\n"
+            f"Date: {date_str}\n"
+            "X-Mailer: VyOS SMTP Client Extension\n\n"
+            "Hello,\n\n"
+            f"{message_content}\n\n"
+            f"Timestamp: {datetime.now().isoformat()}\n"
+            f"Outbound Route: {active_profile}\n"
+            "Status: System verification successful.\n"
+        )
+
+        cmd = ['msmtp', f'--account={active_profile}', target_email]
+
+        try:
+            process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            stdout, stderr = process.communicate(input=email_body)
+
+            if process.returncode == 0:
+                print(f" -> Sent successfully to [{target_email}]")
+                success_count += 1
+            else:
+                print(f" -> Failed sending to [{target_email}]: {stderr.strip()}")
+        except Exception as e:
+            print(f" -> Execution error sending to [{target_email}]: {str(e)}")
+
+    print(f"\nCompleted. Successfully delivered {success_count} of {len(enabled_recipients)} emails.")
+    sys.exit(0 if success_count > 0 else 1)
+
+
+if __name__ == '__main__':
+    # Safely extract the raw string variable block sitting at argument index 1
+    input_sentence = ""
+    if len(sys.argv) > 1:
+        input_sentence = sys.argv[1]
+        
+    send_test_email(input_sentence)
+


### PR DESCRIPTION
Configuration CLI examples:
===================
set system email active-profile 'yahoo'
set system email profile gmail authentication 'oauth2'
set system email profile gmail from-email 'from-test@gmail.com'
set system email profile gmail oauth2 client-id '125945320076-xxxxxxxxxxxxxxxxx.apps.googleusercontent.com'
set system email profile gmail oauth2 client-secret 'GOCSPX-yyyyyyyyyyyyyyyyyyyyyyy'
set system email profile gmail oauth2 refresh-token '1//04baREhMe1btXCgYIARAAGAQSNwF-L9IrfrYwmCBi1YVWjqZUUm5VuENTel8MlyfkfuIpQfkpRwDMQvz03mYJITcgd0G6K0vCt3s'
set system email profile gmail oauth2 token-url 'https://oauth2.googleapis.com/token'
set system email profile gmail password 'zzzzzzzzzzzzzzzzz'
set system email profile gmail port '587'
set system email profile gmail security 'starttls'
set system email profile gmail smtp-host 'smtp.gmail.com'
set system email profile gmail username 'test@gmail.com'
set system email profile yahoo authentication 'oauth2'
set system email profile yahoo from-email 'from-test@yahoo.ca'
set system email profile yahoo oauth2 client-id 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
set system email profile yahoo oauth2 client-secret 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
set system email profile yahoo oauth2 refresh-token 'AJpAWWoisDBkYWqR6Mc3NpeTdVrg~001~.ognDzoJT3sn.AREAVku3w--'
set system email profile yahoo oauth2 scope 'mail-w'
set system email profile yahoo oauth2 token-url 'https://api.login.yahoo.com/oauth2/get_token'
set system email profile yahoo password 'cccccccccccccccccccc'
set system email profile yahoo port '587'
set system email profile yahoo security 'starttls'
set system email profile yahoo smtp-host 'smtp.mail.yahoo.com'
set system email profile yahoo username 'test@yahoo.ca'
set system email recipient test1 email 'test1@gmail.com'
set system email recipient test1 enable
set system email recipient test1 subject 'iGOS email notification'
set system email recipient test2 email 'test2@yahoo.ca'
set system email recipient test2 enable
set system email recipient test2 subject 'iGOS email notification'

Operational Mode CLI
==============
generate test-email [message] <your-custom-message>
generate test-email message 'igos oauth2 smtp yahoo test message'

Notes:
====
1) user/password is easiest to set up but also being deprecated (gmail and yahoo still support this through generating a 16 char APP password under profile->security settings.  There may be others
2) oauth2 is becoming more prevalent, but difficult to setup.  gmail was verified working with oauth2 but yahoo, and MS Entra/Office 365 was unsuccessful.  The issues appear to be on the email server side with permissions.  Yahoo passed the oauth2 auth phase but permissions denied allowing smtp emails through.  The oauth2 setup on the server/host side is wildly different, but the common elements are you have to create a client oauth2 APP and under their developers cloud services or select from a set of pre-defined ones (MS Entra), configure the re-direct uri to an oauth2 service like https://oauth.pstmn.io/v1, or a built in one (gmail) and this creates the client id and client secret for that oauth2 app.  Then you have to obtain a time limited authorization code by either running a curl command or browse to predefined online url with the app/client id, secret where you would be directed to enter your account creds or redirected to a url.  Both will include a "code=" portion in the url that is used to acquire a refresh token using a generic curl command from any internet connected device:

curl -s \2  -d "client_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \3  -d "client_secret=yyyyyyyyyyyyyyyyy" \4  -d "code=PASTE_CODE_HERE" \5  -d "grant_type=authorization_code" \6  -d "redirect_uri=https://developers.google.com/oauthplayground" \7  https://oauth2.googleapis.com/token | jq .

It is recommended to use Copilot or other AI to recreate the steps based on the service to acquire the oauth2 configuration needed.  You can use the op-mode "generate test-email [message <test>] to verify as below:

igos@igos:/usr/libexec/vyos$ generate test-email message "igos gmail oauth2 test message"
Using active SMTP profile: [gmail]
Processing delivery to 2 enabled recipient(s)...
 -> Sent successfully to [xxxxxxxxxx@gmail.com]
 -> Sent successfully to [yyyyyyyyyy@yahoo.ca]

Completed. Successfully delivered 2 of 2 emails.
The test email contents from the gmail/yahoo recipients inbox:
=======================================
iGOS email notification: Operational Test Message
Inbox

xxxxxxxxx@gmail.com
12:16 PM (2 minutes ago)
to me

Hello,

Custom Message:
igos gmail oauth2 test message

Timestamp: 2026-07-17T16:16:53.649694
Outbound Route: gmail
Status: System verification successful.
=========================================

Message View
iGOS email notification: Operational Test Message
Inbox

Inbox
Message. For JAWS, turn virtual PC Cursor on if needed.

xxxxxxx xxxxx
To:  me
 · 
Fri, Jul 17 at 12:16 p.m.
Message Body
Hello,

Custom Message:
igos gmail oauth2 test message

Timestamp: 2026-07-17T16:16:54.757790
Outbound Route: gmail
Status: System verification successful.
===========================================