### PR TITLE
Add support for tpm with wireguard

### DIFF
--- a/interface-definitions/interfaces_wireguard.xml.in
+++ b/interface-definitions/interfaces_wireguard.xml.in
@@ -59,11 +59,6 @@
               #include <include/constraint/wireguard-keys.xml.i>
             </properties>
           </leafNode>
-          <leafNode name="private-key-file">
-            <properties>
-              <help>Path to file holding private key</help>
-            </properties>
-          </leafNode>
           <leafNode name="private-key-tpm">
             <properties>
               <help>File name with .pub and .priv files containing tpm sealed key</help>

--- a/interface-definitions/interfaces_wireguard.xml.in
+++ b/interface-definitions/interfaces_wireguard.xml.in
@@ -59,6 +59,16 @@
               #include <include/constraint/wireguard-keys.xml.i>
             </properties>
           </leafNode>
+          <leafNode name="private-key-file">
+            <properties>
+              <help>Path to file holding private key</help>
+            </properties>
+          </leafNode>
+          <leafNode name="private-key-tpm">
+            <properties>
+              <help>File name with .pub and .priv files containing tpm sealed key</help>
+            </properties>
+          </leafNode>
           <tagNode name="peer">
             <properties>
               <help>peer alias</help>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -309,6 +309,33 @@
                 </children>
                 <command>${vyos_op_scripts_dir}/pki.py generate_pki --pki-type wireguard --key</command>
               </node>
+              <tagNode name="key-pair-tpm">
+                <properties>
+                  <help>Generate WireGuard public/private key-pair, sealing private key via tpm in specified file.pub and file.priv</help>
+                  <completionHelp>
+                    <list>&lt;filename&gt;</list>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <node name="install">
+                    <properties>
+                      <help>Generate CLI commands to install WireGuard key to configuration</help>
+                    </properties>
+                    <children>
+                      <tagNode name="interface">
+                        <properties>
+                          <help>WireGuard Interface used in install command</help>
+                          <completionHelp>
+                            <path>interfaces wireguard</path>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/pki.py generate_pki --pki-type wireguard --key --tpm-file "$5" --interface "$8" --install</command>
+                      </tagNode>
+                    </children>
+                  </node>
+                </children>
+                <command>${vyos_op_scripts_dir}/pki.py generate_pki --pki-type wireguard --key --tpm-file "$5"</command>
+              </tagNode>
               <node name="preshared-key">
                 <properties>
                   <help>Generate WireGuard pre-shared key</help>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -311,7 +311,7 @@
               </node>
               <tagNode name="key-pair-tpm">
                 <properties>
-                  <help>Generate WireGuard public/private key-pair, sealing private key via tpm in specified file.pub and file.priv</help>
+                  <help>Generate WireGuard public/private key-pair, sealing private key via tpm in specified file.pub and file.priv, saved in /config/auth/wireguard</help>
                   <completionHelp>
                     <list>&lt;filename&gt;</list>
                   </completionHelp>

--- a/python/vyos/tpm.py
+++ b/python/vyos/tpm.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 default_pcrs = ['0','2','4','7']
 tpm_handle = 0x81000000
+tpm_key_save_dir = "/config/auth/wireguard/"
 
 def init_tpm(clear=False):
     """
@@ -108,7 +109,7 @@ def read_tpm_key_file(public_obj, private_obj):
             raise Exception('read_tpm_key: Failed to re-create primary key')
 
         load_context_file = os.path.join(tpm_dir, 'load.ctx')
-        code, output = rc_cmd(f'tpm2_load -C {primary_context_file} -u {public_obj} -r {private_obj} -c {load_context_file}')
+        code, output = rc_cmd(f'tpm2_load -C {primary_context_file} -u {tpm_key_save_dir + public_obj} -r {tpm_key_save_dir + private_obj} -c {load_context_file}')
         if code != 0:
             print(output)
             raise Exception('read_tpm_key: Failed to load object')
@@ -137,10 +138,10 @@ def write_tpm_key_file(key, save_file):
         with open(key_file, 'wb') as f:
             f.write(key)
 
-        public_obj = save_file + '.pub'
-        private_obj = save_file + '.priv'
-        dir_path = Path(os.path.dirname(save_file))
-        dir_path.mkdir(parents=True, exist_ok=True)
+        public_obj = tpm_key_save_dir + save_file + '.pub'
+        private_obj = tpm_key_save_dir + save_file + '.priv'
+        dir_path = Path(tpm_key_save_dir + save_file)
+        dir_path.parent.mkdir(parents=True, exist_ok=True)
         code, output = rc_cmd(
             f'tpm2_create -g sha256 \
             -u {public_obj} -r {private_obj} \

--- a/python/vyos/tpm.py
+++ b/python/vyos/tpm.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 
 from vyos.utils.process import rc_cmd
+from pathlib import Path
 
 default_pcrs = ['0','2','4','7']
 tpm_handle = 0x81000000
@@ -95,6 +96,61 @@ def write_tpm_key(key, index=0, pcrs=default_pcrs):
         if code != 0:
             raise Exception('write_tpm_key: Failed to write object to TPM')
 
+def read_tpm_key_file(public_obj, private_obj):
+    """
+    Read existing key on TPM with provided public and private files
+    """
+    with tempfile.TemporaryDirectory() as tpm_dir:
+
+        primary_context_file = os.path.join(tpm_dir, 'primary.ctx')
+        code, output = rc_cmd(f'tpm2_createprimary -C e -g sha256 -G rsa -c {primary_context_file}')
+        if code != 0:
+            raise Exception('read_tpm_key: Failed to re-create primary key')
+
+        load_context_file = os.path.join(tpm_dir, 'load.ctx')
+        code, output = rc_cmd(f'tpm2_load -C {primary_context_file} -u {public_obj} -r {private_obj} -c {load_context_file}')
+        if code != 0:
+            print(output)
+            raise Exception('read_tpm_key: Failed to load object')
+
+        tpm_key_file = os.path.join(tpm_dir, 'tpm_key.key')
+        code, output = rc_cmd(f'tpm2_unseal -c {load_context_file} -o {tpm_key_file}')
+        if code != 0:
+            raise Exception('read_tpm_key: Failed to read key from TPM')
+
+        with open(tpm_key_file, 'rb') as f:
+            tpm_key = f.read()
+
+        return tpm_key
+
+def write_tpm_key_file(key, save_file):
+    """
+    Write encrypted TPM key and saves them to save_file.pub and save_file.priv files
+    """
+    with tempfile.TemporaryDirectory() as tpm_dir:
+        primary_context_file = os.path.join(tpm_dir, 'primary.ctx')
+        code, output = rc_cmd(f'tpm2_createprimary -C e -g sha256 -G rsa -c {primary_context_file}')
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to create primary key')
+
+        key_file = os.path.join(tpm_dir, 'crypt.key')
+        with open(key_file, 'wb') as f:
+            f.write(key)
+
+        public_obj = save_file + '.pub'
+        private_obj = save_file + '.priv'
+        dir_path = Path(os.path.dirname(save_file))
+        dir_path.mkdir(parents=True, exist_ok=True)
+        code, output = rc_cmd(
+            f'tpm2_create -g sha256 \
+            -u {public_obj} -r {private_obj} \
+            -C {primary_context_file} -i {key_file}')
+
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to create object')
+
+        return public_obj, private_obj
+
 # PERLE - added check for tpm support
 
 from vyos.utils.process import cmd
@@ -139,7 +195,7 @@ def tpm_allowed():
     Note:
         For now, it returns True/False based on /sys/class/tpm/tpm0 existing or not.
     """
-    return tpm_enabled() and tpm_exist() 
+    return tpm_enabled() and tpm_exist()
 
 
 def tpm_enable():

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import base64
 
 from glob import glob
 from sys import exit
@@ -38,6 +39,7 @@ from vyos.utils.network import is_wireguard_key_pair
 from vyos.utils.process import call
 from vyos import ConfigError
 from vyos import airbag
+from vyos import tpm
 airbag.enable()
 
 
@@ -94,8 +96,31 @@ def verify(wireguard):
     verify_bond_bridge_member(wireguard)
     verify_mirror_redirect(wireguard)
 
-    if 'private_key' not in wireguard:
+    private_keys = [k for k in wireguard.keys() if 'private_key' in k]
+    if not private_keys:
         raise ConfigError('Wireguard private-key not defined')
+
+    if len(private_keys) != 1:
+        raise ConfigError('Wireguard private-key defined multiple times')
+
+    if 'private_key_file' in wireguard:
+        # Validation done here instead of in xml constraint due to permission issues
+        # File can technically exist, but the constraint is checked without sudo permission
+        if not os.path.exists(wireguard['private_key_file']):
+            raise ConfigError('Wireguard private-key-file cannot be located')
+        with open(wireguard['private_key_file']) as f:
+            wireguard['private_key'] = f.read().strip()
+        del wireguard['private_key_file']
+
+    elif 'private_key_tpm' in wireguard:
+        if tpm.tpm_exist:
+            save_file = wireguard['private_key_tpm']
+            pub = save_file + '.pub'
+            priv = save_file + '.priv'
+            reread_key = base64.b64encode(tpm.read_tpm_key_file(pub, priv)).decode("utf-8")
+            # wireguard['private_key'] = wireguard['private_key_tpm']
+            wireguard['private_key'] = reread_key
+            del wireguard['private_key_tpm']
 
     if 'port' in wireguard and 'port_changed' in wireguard:
         listen_port = int(wireguard['port'])

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -103,15 +103,6 @@ def verify(wireguard):
     if len(private_keys) != 1:
         raise ConfigError('Wireguard private-key defined multiple times')
 
-    if 'private_key_file' in wireguard:
-        # Validation done here instead of in xml constraint due to permission issues
-        # File can technically exist, but the constraint is checked without sudo permission
-        if not os.path.exists(wireguard['private_key_file']):
-            raise ConfigError('Wireguard private-key-file cannot be located')
-        with open(wireguard['private_key_file']) as f:
-            wireguard['private_key'] = f.read().strip()
-        del wireguard['private_key_file']
-
     elif 'private_key_tpm' in wireguard:
         if tpm.tpm_exist():
             save_file = wireguard['private_key_tpm']

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -108,6 +108,12 @@ def verify(wireguard):
             save_file = wireguard['private_key_tpm']
             pub = save_file + '.pub'
             priv = save_file + '.priv'
+            # We will save all tpm sealed private keys in /config/auth/wireguard
+            save_dir = "/config/auth/wireguard/"
+
+            if not os.path.exists(save_dir + pub) or not os.path.exists(save_dir + priv):
+                raise ConfigError('Wireguard private-key-tpm .pub/.priv files cannot be located')
+
             reread_key = base64.b64encode(tpm.read_tpm_key_file(pub, priv)).decode("utf-8")
             wireguard['private_key'] = reread_key
             del wireguard['private_key_tpm']

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -113,12 +113,11 @@ def verify(wireguard):
         del wireguard['private_key_file']
 
     elif 'private_key_tpm' in wireguard:
-        if tpm.tpm_exist:
+        if tpm.tpm_exist():
             save_file = wireguard['private_key_tpm']
             pub = save_file + '.pub'
             priv = save_file + '.priv'
             reread_key = base64.b64encode(tpm.read_tpm_key_file(pub, priv)).decode("utf-8")
-            # wireguard['private_key'] = wireguard['private_key_tpm']
             wireguard['private_key'] = reread_key
             del wireguard['private_key_tpm']
 

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -907,8 +907,8 @@ def generate_wireguard_key(interface=None, install=False, tpm_file=None):
     # If tpm file is specified, seal the key using tpm_file as base name for public and private objects
     # Generated tpm_file.pub and tpm_file.priv files are required to unseal / decode private key
     if tpm_file:
-        if not tpm.tpm_enabled:
-            print('Error: tpm is not enabled!  Cannot use tpm commands!')
+        if not tpm.tpm_exist():
+            print('Error: tpm does not exist!  Cannot use tpm commands!')
             return
         else:
             tpm.write_tpm_key_file(base64.b64decode(private_key), tpm_file)

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import ipaddress
 import os
 import re
@@ -26,6 +27,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 
 import vyos.opmode
 
+from vyos import tpm
 from vyos.base import Warning
 from vyos.config import Config
 from vyos.config import config_dict_mangle_acme
@@ -318,7 +320,7 @@ def install_openvpn_key(name, key_data, key_version='1'):
     install_into_config(conf, config_paths)
 
 
-def install_wireguard_key(interface, private_key, public_key):
+def install_wireguard_key(interface, private_key, public_key, tpm_enabled=None):
     # Show conf commands for installing wireguard key pairs
     from vyos.ifconfig import Section
 
@@ -327,9 +329,14 @@ def install_wireguard_key(interface, private_key, public_key):
         exit(1)
 
     # Check if we are running in a config session - if yes, we can directly write to the CLI
-    install_into_config(
-        conf, [f"interfaces wireguard {interface} private-key '{private_key}'"]
-    )
+    if tpm_enabled:
+        install_into_config(
+            conf, [f"interfaces wireguard {interface} private-key-tpm '{private_key}'"]
+        )
+    else:
+        install_into_config(
+            conf, [f"interfaces wireguard {interface} private-key '{private_key}'"]
+        )
 
     print(f"Corresponding public-key to use on peer system is: '{public_key}'")
 
@@ -893,12 +900,22 @@ def generate_openvpn_key(name, install=False, file=False):
         write_file(f'{name}.key', result)
 
 
-def generate_wireguard_key(interface=None, install=False):
+def generate_wireguard_key(interface=None, install=False, tpm_file=None):
     private_key = cmd('wg genkey')
     public_key = cmd('wg pubkey', input=private_key)
 
+    # If tpm file is specified, seal the key using tpm_file as base name for public and private objects
+    # Generated tpm_file.pub and tpm_file.priv files are required to unseal / decode private key
+    if tpm_file:
+        if not tpm.tpm_enabled:
+            print('Error: tpm is not enabled!  Cannot use tpm commands!')
+            return
+        else:
+            tpm.write_tpm_key_file(base64.b64decode(private_key), tpm_file)
+            private_key = tpm_file
+
     if interface and install:
-        install_wireguard_key(interface, private_key, public_key)
+        install_wireguard_key(interface, private_key, public_key, tpm_file)
     else:
         print(f'Private key: {private_key}')
         print(f'Public key: {public_key}', end='\n\n')
@@ -1158,6 +1175,7 @@ def generate_pki(
     self_sign: typing.Optional[bool],
     key: typing.Optional[bool],
     psk: typing.Optional[bool],
+    tpm_file: typing.Optional[str],
     interface: typing.Optional[str],
     peer: typing.Optional[str],
 ):
@@ -1196,7 +1214,7 @@ def generate_pki(
             os.environ['vyos_libexec_dir'] = '/usr/libexec/vyos'
 
             if key:
-                generate_wireguard_key(interface, install=install)
+                generate_wireguard_key(interface, install=install, tpm_file=tpm_file)
             if psk:
                 generate_wireguard_psk(interface, peer=peer, install=install)
     except KeyboardInterrupt:

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -330,9 +330,12 @@ def install_wireguard_key(interface, private_key, public_key, tpm_enabled=None):
 
     # Check if we are running in a config session - if yes, we can directly write to the CLI
     if tpm_enabled:
+        private_key_path = "/config/auth/wireguard/"
         install_into_config(
             conf, [f"interfaces wireguard {interface} private-key-tpm '{private_key}'"]
         )
+        print(f"Sealed private-key .pub file created: '{private_key_path}{private_key}.pub'")
+        print(f"Sealed private-key .priv file created: '{private_key_path}{private_key}.priv'")
     else:
         install_into_config(
             conf, [f"interfaces wireguard {interface} private-key '{private_key}'"]


### PR DESCRIPTION
Add support for using tpm with Wireguard private keys through 2 main changes, one in op mode and one in conf mode.  

In op mode, use the command 'generate pki wireguard key-pair-tpm ...' to generate a matching public and private key, with the private key being sealed via tpm in .pub and .priv files.  Using the optional commands 'install interface ...' will display the corresponding 'set' command in conf mode that is required to use this key.  

In configure mode, use the command 'set interface wireguard ... private-key-tpm' to have Wireguard actually use this newly generated private tpm key.